### PR TITLE
ci: set explicit app env mode for PR and main runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  VITE_APP_ENV: ${{ github.event_name == 'pull_request' && 'staging' || 'production' }}
+  VITE_ENABLE_CRASH_REPORTS: "false"
+
 jobs:
   frontend:
     name: Frontend Checks

--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ Current variables:
 
 Validation is fail-fast at app startup (`src/shared/config/env.ts`).
 Never commit real secrets: `.env*` files are git-ignored except `.env.example`.
+In CI, environment is set explicitly:
+
+- pull requests to `main` run with `VITE_APP_ENV=staging`
+- pushes to `main` run with `VITE_APP_ENV=production`
 
 ## Privacy and Safety Principles
 


### PR DESCRIPTION
## Summary

Added explicit CI environment configuration to make build/test behavior deterministic across events.

Changes:

- Updated GitHub Actions workflow to set VITE_* variables at workflow level:
  - `VITE_APP_ENV=staging` for `pull_request` runs
  - `VITE_APP_ENV=production` for `push` runs on `main`
  - `VITE_ENABLE_CRASH_REPORTS=false` for CI runs
- Updated README environment section to document this CI behavior.
 
Why:

- Avoids relying on implicit defaults (development) in CI.
- Ensures PR validation is predictable (staging) while main branch runs reflect production mode.
- Keeps CI safe by disabling crash-report sending in automated runs.

## Scope

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs/infra

## Validation

- [x] `npm run check`
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] Additional manual verification (if needed)

Additional notes:

- Verified workflow syntax and logic changes in [ci.yml](https://file+.vscode-resource.vscode-cdn.net/home/shin/.vscode/extensions/openai.chatgpt-0.4.78-linux-x64/webview/#).
- Confirmed README updates match actual CI env behavior.

## Risks

- VITE_APP_ENV is now event-dependent in CI; if future workflows add new event types, mapping logic may need updates.
- If production mode later enables stricter integrations, CI on main may require additional mocks/guards.
- Rust checks were not re-run manually in this small CI/docs-only change (existing Rust job remains in workflow).
