### PR TITLE
docs: enforce branch policy and add local agent guides

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default ownership
+* @shinokamix
+
+# Area ownership
+/.github/ @shinokamix
+/src/ @shinokamix
+/src-tauri/ @shinokamix
+/e2e/ @shinokamix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,34 @@ env:
   VITE_ENABLE_CRASH_REPORTS: "false"
 
 jobs:
+  branch-policy:
+    name: Branch Policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Validate source branch name
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+          echo "Branch: ${BRANCH_NAME}"
+
+          if [[ "${BRANCH_NAME}" == "main" ]]; then
+            echo "main is allowed for push events."
+            exit 0
+          fi
+
+          pattern='^(feat|fix|refactor|chore|docs|test|ci)/[a-z0-9]+(-[a-z0-9]+)*$'
+          if [[ ! "${BRANCH_NAME}" =~ ${pattern} ]]; then
+            echo "Invalid branch name: ${BRANCH_NAME}"
+            echo "Expected format: <type>/<short-kebab-name>"
+            echo "Allowed types: feat, fix, refactor, chore, docs, test, ci"
+            exit 1
+          fi
+
+          echo "Branch name matches policy."
+
   frontend:
     name: Frontend Checks
     runs-on: ubuntu-latest
@@ -124,7 +152,7 @@ jobs:
   ci:
     name: CI (required)
     runs-on: ubuntu-latest
-    needs: [frontend, rust-tauri, e2e-smoke]
+    needs: [branch-policy, frontend, rust-tauri, e2e-smoke]
     timeout-minutes: 5
     steps:
       - name: Final status

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,56 @@ Follow these rules when making changes in this repository.
 
 ## Workflow
 
-- If current branch is `main`, create a new branch from `main` (do not commit to `main` directly).
+- Every new task (feature, fix, refactor, docs/test/ci change) must start in a fresh branch created from `main`.
+- Do not reuse an old task branch for a new request, even if branch names are similar.
+- Never commit directly to `main`.
+- If user explicitly asks to continue an existing branch, continue only that same scope.
+- If worktree is dirty before starting a new task, stop and ask the user how to proceed.
 - Make focused, minimal changes with a clear rationale.
 - Run all required local checks before finishing.
 - Assume `main` is protected and merges require green required CI checks.
 - Do NOT create or open pull requests; the user will do that.
+
+## Branch start protocol (required)
+
+Run this at the start of each new task:
+
+1. Ensure worktree is clean (`git status --short`).
+2. Sync `main` from remote.
+3. Create a new branch from updated `main`.
+4. Confirm current branch is not `main`.
+
+Suggested commands:
+
+```bash
+git fetch origin main
+git switch main
+git pull --ff-only origin main
+git switch -c <type>/<short-kebab-name>
+git branch --show-current
+```
+
+If `origin` is not configured, use local `main` as the source branch.
+
+## Execution contract (required)
+
+At task start:
+
+1. Classify scope (`feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`).
+2. Create a branch name from that scope.
+3. Keep change set focused to one logical task.
+
+During implementation:
+
+- Prefer reading architecture context first: `README.md`, `ARCHITECTURE.md`, and nearest local docs.
+- For risky edits, run targeted checks first, then run required full checks.
+- Do not make unrelated refactors in the same task branch.
+
+At task finish, report:
+
+- Files changed and why.
+- Checks run and results.
+- Remaining risks or follow-ups.
 
 ## Branch naming
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,50 @@
 # Contributing
 
+## Prerequisites
+
+- Node.js 20+
+- npm 10+
+- Rust stable toolchain
+
+## Quick start
+
+```bash
+npm ci
+npm run check
+cargo check --manifest-path src-tauri/Cargo.toml
+```
+
 ## Workflow
 
-1. Create a branch from `main`.
+1. Start every new task in a fresh branch created from `main`.
 2. Make focused changes.
 3. Run local checks.
 4. Open a PR with a clear scope and rationale.
 5. Merge only after required CI checks pass.
+
+Branch policy is strict:
+
+- One task = one branch.
+- Never push commits directly to `main`.
+- Do not reuse previous task branches for new work.
+- If you need to continue an old branch, do it only for the same task scope.
+
+Recommended start commands:
+
+```bash
+git fetch origin main
+git switch main
+git pull --ff-only origin main
+git switch -c <type>/<short-kebab-name>
+```
 
 `main` is protected:
 
 - Direct pushes to `main` are not allowed.
 - Changes must go through pull requests.
 - Merge is allowed only when required CI checks are green.
+
+If your local worktree is dirty before starting a new task, either commit/stash first or open a separate branch for that existing work.
 
 ## Branch naming
 
@@ -25,6 +57,8 @@ Use one of these prefixes:
 - `docs/<short-kebab-name>`
 - `test/<short-kebab-name>`
 - `ci/<short-kebab-name>`
+
+Branch names are validated in CI for pull requests to `main`.
 
 ## Local checks
 
@@ -41,10 +75,26 @@ cargo check --manifest-path src-tauri/Cargo.toml
 ## Coding rules
 
 - Keep architecture FSD-oriented (`app`, `features`, `shared`).
+- Respect dependency direction:
+  - `app` may depend on `features` and `shared`.
+  - `features` may depend only on `shared`.
+  - `shared` must not import from `app` or `features`.
 - Put global shell state in `app/model`.
 - Put user actions/business flows in `features/*`.
 - Reusable UI primitives belong to `shared/ui`.
 - Keep changes small and testable.
+- Do not add dependency changes without clear need.
+
+## Scope guidance
+
+- Keep PRs single-purpose and reviewable.
+- Split unrelated work into separate branches/PRs.
+- Update docs when behavior or project workflow changes.
+
+## Ownership and review routing
+
+- `CODEOWNERS` is used for automatic reviewer assignment.
+- Keep ownership mappings current when new top-level areas are added.
 
 ## PR checklist
 

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md - e2e
+
+This file applies to `e2e/**` and extends root `AGENTS.md`.
+
+## Scope
+
+- Playwright end-to-end tests and supporting test assets.
+- Preserve smoke-test reliability and CI friendliness.
+
+## Test authoring rules
+
+- Keep tests deterministic; avoid arbitrary sleeps/timeouts.
+- Prefer resilient selectors and explicit assertions.
+- Do not commit focused-only flags (`test.only`, `describe.only`).
+- Keep each test scoped to one user journey.
+
+## Validation
+
+- Run `npm run e2e` after e2e changes.
+- If app behavior changed, ensure `npm run check` also passes before finishing.

--- a/src-tauri/AGENTS.md
+++ b/src-tauri/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md - src-tauri
+
+This file applies to `src-tauri/**` and extends root `AGENTS.md`.
+
+## Scope
+
+- Rust/Tauri desktop shell code and config in `src-tauri`.
+- Keep changes minimal and focused on desktop/runtime concerns.
+
+## Rust quality gates
+
+- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
+- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
+- `cargo check --manifest-path src-tauri/Cargo.toml --all-targets`
+
+## Implementation rules
+
+- Do not weaken lints or checks to make CI pass.
+- Avoid broad dependency upgrades unless required for the task.
+- Keep security-sensitive config deliberate (updater/signing/release settings).
+- If frontend and Tauri must change together, keep interface contracts explicit.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md - src
+
+This file applies to `src/**` and extends root `AGENTS.md`.
+
+## Scope
+
+- React + TypeScript application code only.
+- Keep architecture FSD-oriented: `app`, `features`, `shared`.
+
+## Dependency direction (required)
+
+- `app` may depend on `features` and `shared`.
+- `features` may depend only on `shared`.
+- `shared` must not import from `app` or `features`.
+
+## Implementation rules
+
+- Put global shell/app state in `app/model`.
+- Put user-facing business actions in `features/*`.
+- Place reusable UI primitives in `shared/ui`.
+- Prefer small, focused changes; avoid unrelated refactors.
+- Do not introduce new dependencies without clear need.
+
+## Validation
+
+- Run targeted checks for touched code while iterating.
+- Before finishing, required root checks must pass (`npm run check` and Rust check from root policy).


### PR DESCRIPTION
## Summary

Updated repository contribution and agent workflow standards to reduce ambiguity and enforce consistent delivery flow.

What changed:
- Strengthened root `AGENTS.md` with strict branch rules (`one task = one fresh branch from main`), required preflight, and execution/reporting contract.
- Expanded `CONTRIBUTING.md` with prerequisites, quick start, stricter branching policy, scope guidance, and ownership notes.
- Added `.github/CODEOWNERS` for automatic review routing.
- Added CI branch-name enforcement job in `.github/workflows/ci.yml` and wired it into required `ci` aggregate job.
- Added local agent instructions:
  - `src/AGENTS.md`
  - `src-tauri/AGENTS.md`
  - `e2e/AGENTS.md`

Why:
- Agents and contributors now have deterministic task-start behavior.
- Branch naming and branching strategy are enforced, not just documented.
- Review ownership and area-specific guidance improve throughput and reduce mistakes.

## Scope

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Infrastructure / CI
- [x] Documentation

## Validation

Executed and passed:
- `npm run check`
- `cargo check --manifest-path src-tauri/Cargo.toml`

Manual verification:
- Reviewed changed docs for consistency between root and local rules.
- Verified branch-name regex policy with a local shell check against current branch (`docs/agent-branch-policy`).

- [x] `npm run check`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] Manual verification (if applicable)

## Risks

- Existing or future branches not matching the naming regex will fail CI until renamed.
- Root and local `AGENTS.md` files can drift over time; periodic sync is needed.

## Before requesting review

- [x] Local checks pass
- [x] Documentation updated if needed
- [x] CI is green