### PR TITLE
ci/beta release changelog gates v2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,6 +30,7 @@ Known tradeoffs, limitations, or follow-ups.
 
 - [ ] Docs updated
 - [ ] `CHANGELOG.md` updated for user-facing changes
+- [ ] Internal-only change: used `[skip-changelog]` in PR title/body with rationale
 - [ ] Docs not needed (explain in Summary)
 
 ## Before requesting review

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   VITE_APP_ENV: ${{ github.event_name == 'pull_request' && 'staging' || 'production' }}
@@ -45,6 +46,71 @@ jobs:
           fi
 
           echo "Branch name matches policy."
+
+  changelog-policy:
+    name: Changelog Policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Validate changelog update policy
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName !== "pull_request") {
+              core.info("Not a pull_request event. Skipping changelog policy.");
+              return;
+            }
+
+            const pullRequest = context.payload.pull_request;
+            if (!pullRequest) {
+              core.setFailed("Pull request payload is missing.");
+              return;
+            }
+
+            const prText = `${pullRequest.title}\n${pullRequest.body ?? ""}`;
+            if (/\[skip-changelog\]/i.test(prText)) {
+              core.info("Found [skip-changelog] marker. Skipping changelog requirement.");
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const files = [];
+
+            for (let page = 1; ; page += 1) {
+              const response = await github.rest.pulls.listFiles({
+                owner,
+                repo,
+                pull_number: pullRequest.number,
+                per_page: 100,
+                page
+              });
+
+              files.push(...response.data.map((file) => file.filename));
+              if (response.data.length < 100) {
+                break;
+              }
+            }
+
+            const touchesUserFacingPaths = files.some(
+              (filePath) => filePath.startsWith("src/") || filePath.startsWith("src-tauri/")
+            );
+
+            if (!touchesUserFacingPaths) {
+              core.info("No changes in src/** or src-tauri/**. Changelog update is not required.");
+              return;
+            }
+
+            const hasChangelogUpdate = files.includes("CHANGELOG.md");
+            if (!hasChangelogUpdate) {
+              core.setFailed(
+                "This PR changes src/** or src-tauri/** but does not update CHANGELOG.md. Add an entry to ## [Unreleased] or include [skip-changelog] in the PR title/body for internal-only changes."
+              );
+              return;
+            }
+
+            core.info("Changelog policy passed.");
 
   frontend:
     name: Frontend Checks
@@ -143,7 +209,7 @@ jobs:
   ci:
     name: CI (required)
     runs-on: ubuntu-latest
-    needs: [branch-policy, frontend, rust-tauri, e2e-smoke]
+    needs: [branch-policy, changelog-policy, frontend, rust-tauri, e2e-smoke]
     timeout-minutes: 5
     steps:
       - name: Final status

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -5,14 +5,94 @@ on:
 
 permissions:
   contents: write
+  checks: read
 
 concurrency:
   group: release-beta
   cancel-in-progress: false
 
 jobs:
+  preflight:
+    name: Beta Preflight
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate branch and required checks
+        uses: actions/github-script@v7
+        env:
+          REQUIRED_CHECKS_JSON: '["CI (required)"]'
+        with:
+          script: |
+            if (context.ref !== "refs/heads/main") {
+              core.setFailed(`Release Beta can run only from main. Current ref: ${context.ref}`);
+              return;
+            }
+
+            const requiredChecks = JSON.parse(process.env.REQUIRED_CHECKS_JSON ?? "[]");
+            if (!Array.isArray(requiredChecks) || requiredChecks.length === 0) {
+              core.setFailed("REQUIRED_CHECKS_JSON must define at least one required check name.");
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const checkRuns = [];
+
+            for (let page = 1; ; page += 1) {
+              const response = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref: context.sha,
+                per_page: 100,
+                page
+              });
+
+              checkRuns.push(...response.data.check_runs);
+              if (response.data.check_runs.length < 100) {
+                break;
+              }
+            }
+
+            const pickLatestRun = (runs) => {
+              return runs
+                .slice()
+                .sort((a, b) => {
+                  const aTime = new Date(a.completed_at || a.started_at || a.created_at).getTime();
+                  const bTime = new Date(b.completed_at || b.started_at || b.created_at).getTime();
+                  return bTime - aTime;
+                })[0];
+            };
+
+            const failures = [];
+            for (const checkName of requiredChecks) {
+              const matchingRuns = checkRuns.filter((run) => run.name === checkName);
+              if (matchingRuns.length === 0) {
+                failures.push(`Missing required check run: ${checkName}`);
+                continue;
+              }
+
+              const latestRun = pickLatestRun(matchingRuns);
+              const isSuccessful = latestRun.status === "completed" && latestRun.conclusion === "success";
+
+              if (!isSuccessful) {
+                failures.push(
+                  `${checkName} is ${latestRun.status}/${latestRun.conclusion ?? "null"}`
+                );
+              }
+            }
+
+            if (failures.length > 0) {
+              core.setFailed(
+                `Beta preflight failed for ${context.sha}:\n${failures.map((item) => `- ${item}`).join("\n")}`
+              );
+              return;
+            }
+
+            core.info(`Beta preflight passed for ${context.sha}.`);
+
   prepare-release:
     name: Prepare Beta Release
+    needs: preflight
     runs-on: ubuntu-latest
     outputs:
       release_id: ${{ steps.create_or_update.outputs.release_id }}

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -18,14 +18,78 @@ jobs:
       release_id: ${{ steps.create_or_update.outputs.release_id }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract changelog for release notes
+        id: extract_changelog
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+
+            const changelogPath = "CHANGELOG.md";
+            if (!fs.existsSync(changelogPath)) {
+              core.setFailed("CHANGELOG.md was not found at repository root.");
+              return;
+            }
+
+            const raw = fs.readFileSync(changelogPath, "utf8");
+            const normalized = raw.replace(/\r\n/g, "\n");
+
+            const unreleasedHeaderMatch = normalized.match(/^## \[Unreleased\]\s*$/m);
+            if (!unreleasedHeaderMatch || unreleasedHeaderMatch.index === undefined) {
+              core.setFailed("Could not find section '## [Unreleased]' in CHANGELOG.md.");
+              return;
+            }
+
+            const unreleasedStart = unreleasedHeaderMatch.index + unreleasedHeaderMatch[0].length;
+            const changelogAfterHeader = normalized.slice(unreleasedStart).replace(/^\n/, "");
+            const nextSectionIndex = changelogAfterHeader.search(/^## \[/m);
+            const unreleasedBlock =
+              nextSectionIndex === -1
+                ? changelogAfterHeader
+                : changelogAfterHeader.slice(0, nextSectionIndex);
+
+            const unreleased = unreleasedBlock.trim();
+            if (!unreleased) {
+              core.setFailed("Section '## [Unreleased]' in CHANGELOG.md is empty. Add release notes before running beta release.");
+              return;
+            }
+
+            if (!/^\s*-\s+\S+/m.test(unreleased)) {
+              core.setFailed("Section '## [Unreleased]' must include at least one bullet list item ('- ...').");
+              return;
+            }
+
+            core.setOutput("unreleased", unreleased);
+
       - name: Create or update beta release
         id: create_or_update
         uses: actions/github-script@v7
+        env:
+          UNRELEASED_NOTES: ${{ steps.extract_changelog.outputs.unreleased }}
         with:
           script: |
             const tag = "beta";
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const unreleased = process.env.UNRELEASED_NOTES ?? "";
+
+            const shortSha = context.sha.slice(0, 7);
+            const generatedAt = new Date().toISOString();
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            const body = [
+              "## Beta release",
+              "",
+              unreleased,
+              "",
+              "---",
+              `- Commit: \`${shortSha}\``,
+              `- Generated at (UTC): ${generatedAt}`,
+              `- Workflow run: ${runUrl}`
+            ].join("\n");
 
             let release;
             try {
@@ -41,10 +105,9 @@ jobs:
                 tag_name: tag,
                 target_commitish: context.sha,
                 name: "Beta",
-                body: "Latest beta build of overlay-core.",
+                body,
                 draft: false,
-                prerelease: true,
-                generate_release_notes: true
+                prerelease: true
               });
               core.setOutput("release_id", created.data.id.toString());
               return;
@@ -54,7 +117,9 @@ jobs:
               owner,
               repo,
               release_id: release.data.id,
+              target_commitish: context.sha,
               name: "Beta",
+              body,
               draft: false,
               prerelease: true
             });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,11 @@ Git hooks:
 - Add or update tests when behavior changes.
 - Keep CI green before requesting review.
 
+Changelog policy:
+
+- If your PR changes `src/**` or `src-tauri/**` with user-visible impact, update `CHANGELOG.md` (`## [Unreleased]`).
+- For internal-only or technical changes, you may skip changelog by adding `[skip-changelog]` to the PR title or body and explain why.
+
 Use [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md).
 
 ## Architecture and labels

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ npm run check
 cargo check --manifest-path src-tauri/Cargo.toml
 ```
 
+- If your PR changes `src/**` or `src-tauri/**` with user-visible impact, add an entry to `CHANGELOG.md` under `## [Unreleased]`.
+- For internal-only changes, use `[skip-changelog]` in the PR title or body with a short reason.
+
 ## Common scripts
 
 - `npm run dev` - start web dev server

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -19,12 +19,13 @@ Go/no-go:
 
 - [ ] Scope for the cycle is frozen.
 - [ ] No known `P0` or `P1` regressions in beta scope.
-- [ ] Draft release notes are ready.
+- [ ] `## [Unreleased]` in `CHANGELOG.md` is up to date (beta release body is generated from this section).
 
 Execution:
 
 - [ ] Sync local `main`.
 - [ ] Run GitHub Actions workflow: `.github/workflows/release-beta.yml` from `main`.
+- [ ] Verify release page notes are auto-generated from `CHANGELOG.md` `## [Unreleased]`.
 - [ ] Wait for Windows build completion.
 - [ ] Verify prerelease `beta` has fresh artifacts.
 - [ ] Verify `latest.json` exists in beta assets.


### PR DESCRIPTION
Ниже готовый вариант для PR (можно вставлять как есть):

## Summary

- Switched beta release notes to a single source of truth: `CHANGELOG.md` `## [Unreleased]`.
- Updated `.github/workflows/release-beta.yml` to:
  - extract and validate `Unreleased` (fail-fast if missing/empty/no bullet items),
  - generate predictable release body template (`Beta release` + changelog block + metadata),
  - always pass `body` and `target_commitish: context.sha` for both create/update.
- Added beta preflight gate in `release-beta`:
  - run allowed only from `main`,
  - required checks for `context.sha` must be green (currently `CI (required)`).
- Added PR changelog policy in `.github/workflows/ci.yml`:
  - if PR touches `src/**` or `src-tauri/**`, `CHANGELOG.md` update is required,
  - exception: `[skip-changelog]` in PR title/body (case-insensitive).
- Updated docs/process in:
  - `RELEASE_CHECKLIST.md`,
  - `CONTRIBUTING.md`,
  - `README.md`,
  - `.github/PULL_REQUEST_TEMPLATE.md`.
- Why: eliminate manual beta release note drift, prevent releasing from non-green/non-main commits, and enforce changelog discipline automatically.

## Scope

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Infrastructure / CI
- [x] Documentation

## Why now

- Beta release notes were partly manual and could diverge from actual unreleased changes.
- `workflow_dispatch` release had no strict preflight gate, so release could start from wrong branch/commit status.
- Changelog updates relied on manual reviewer attention and were easy to miss in PRs.
- This PR closes all three gaps in one cohesive CI/process update.

## Validation

- [x] `npm run check`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [ ] Manual verification (if applicable)

Details:
- `npm run check` passed (`format:check`, `lint`, `typecheck`, `test:ci`).
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.

## Risks

- Preflight depends on exact required check name (`CI (required)`); if renamed, beta release will fail until updated.
- Changelog policy may require `[skip-changelog]` for some technical PRs touching `src/**` / `src-tauri/**`.
- Manual run of `Release Beta` from GitHub UI still recommended after merge to confirm end-to-end release body update behavior.

## Documentation

- [x] Docs updated
- [ ] `CHANGELOG.md` updated for user-facing changes
- [ ] Docs not needed (explain in Summary)

## Before requesting review

- [x] Local checks pass
- [x] CI is green