### PR TITLE
feat/hotkey settings custom bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Write entries from user impact first, then technical detail.
 - Dedicated global hotkey support with default `Ctrl+Shift+Enter` to toggle temporary overlay interactivity.
 - Tauri hotkey bindings API scaffolding (`get_hotkey_bindings` / `update_hotkey_binding`) for upcoming user-configurable shortcuts in Settings.
 - Single-instance CLI toggle entrypoint (`overlay-core --toggle-overlay`) to trigger visibility toggle in existing app instance.
-- Hotkeys settings panel in app UI with editable toggle shortcut.
+- Hotkeys settings panel in app UI now supports per-action shortcut capture for any key combination (including single-key shortcuts), one-click updates, and full hotkey disable via `Clear`.
 
 ### Changed
 

--- a/src-tauri/src/features/hotkeys/service.rs
+++ b/src-tauri/src/features/hotkeys/service.rs
@@ -56,6 +56,10 @@ pub fn unregister_hotkey(app: &AppHandle, accelerator: &str) -> Result<(), Strin
 
 pub fn register_hotkey_bindings(app: &AppHandle, bindings: &[HotkeyBinding]) -> Result<(), String> {
     for binding in bindings {
+        if binding.accelerator.trim().is_empty() {
+            continue;
+        }
+
         register_hotkey(app, binding.action, &binding.accelerator)?;
     }
 
@@ -74,11 +78,6 @@ pub fn update_hotkey_binding(
     accelerator: String,
 ) -> Result<(), String> {
     let accelerator = accelerator.trim().to_string();
-    if accelerator.is_empty() {
-        return Err("hotkey accelerator cannot be empty".to_string());
-    }
-
-    validate_hotkey_accelerator(&accelerator)?;
 
     let current = hotkeys
         .get(action)
@@ -88,7 +87,18 @@ pub fn update_hotkey_binding(
         return Ok(());
     }
 
-    unregister_hotkey(app, &current)?;
+    if !accelerator.is_empty() {
+        validate_hotkey_accelerator(&accelerator)?;
+    }
+
+    if !current.is_empty() {
+        unregister_hotkey(app, &current)?;
+    }
+
+    if accelerator.is_empty() {
+        hotkeys.set(action, accelerator);
+        return Ok(());
+    }
 
     match register_hotkey(app, action, &accelerator) {
         Ok(()) => {
@@ -96,14 +106,38 @@ pub fn update_hotkey_binding(
             Ok(())
         }
         Err(error) => {
-            if let Err(rollback_error) = register_hotkey(app, action, &current) {
-                eprintln!(
-                    "failed to rollback previous hotkey '{current}' for action '{}': {rollback_error}",
-                    hotkey_action_key(action),
-                );
+            if !current.is_empty() {
+                if let Err(rollback_error) = register_hotkey(app, action, &current) {
+                    eprintln!(
+                        "failed to rollback previous hotkey '{current}' for action '{}': {rollback_error}",
+                        hotkey_action_key(action),
+                    );
+                }
             }
 
             Err(error)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_hotkey_accelerator;
+
+    #[test]
+    fn accepts_single_key_shortcuts() {
+        assert!(validate_hotkey_accelerator("A").is_ok());
+        assert!(validate_hotkey_accelerator("Space").is_ok());
+    }
+
+    #[test]
+    fn accepts_modifier_based_shortcuts() {
+        assert!(validate_hotkey_accelerator("Ctrl+Shift+K").is_ok());
+    }
+
+    #[test]
+    fn rejects_modifier_only_shortcuts() {
+        assert!(validate_hotkey_accelerator("Ctrl").is_err());
+        assert!(validate_hotkey_accelerator("Ctrl+Shift").is_err());
     }
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import { ChatShell } from "@/features/chat-shell";
+import { HotkeySettingsPanel } from "@/features/hotkey-settings";
 import { OverlayHeader } from "@/features/overlay-header";
 import { SettingsModal } from "@/features/settings-modal";
 import { useOverlayShellState } from "@/app/model/use-overlay-shell-state";
@@ -22,7 +23,11 @@ export default function App() {
         <OverlayHeader tauriRuntime={tauriRuntime} onOpenSettings={openSettings} />
         <ChatShell />
 
-        <SettingsModal open={isSettingsOpen} onClose={closeSettings} />
+        <SettingsModal
+          open={isSettingsOpen}
+          onClose={closeSettings}
+          sectionContent={{ hotkeys: <HotkeySettingsPanel tauriRuntime={tauriRuntime} /> }}
+        />
       </section>
     </main>
   );

--- a/src/app/model/__tests__/overlay-ui.integration.test.tsx
+++ b/src/app/model/__tests__/overlay-ui.integration.test.tsx
@@ -28,6 +28,12 @@ describe("App", () => {
     expect(screen.getByRole("tab", { name: /skills/i })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /providers/i })).toBeInTheDocument();
 
+    await user.click(screen.getByRole("tab", { name: /hotkeys/i }));
+    expect(
+      screen.getByText(/open in tauri desktop runtime to configure hotkeys/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/toggle overlay visibility/i)).toBeInTheDocument();
+
     await user.click(screen.getByRole("tab", { name: /providers/i }));
     expect(screen.getByRole("heading", { name: /providers/i })).toBeInTheDocument();
 

--- a/src/features/hotkey-settings/model/__tests__/hotkey-accelerator.test.ts
+++ b/src/features/hotkey-settings/model/__tests__/hotkey-accelerator.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { toHotkeyAccelerator } from "../hotkey-accelerator";
+
+describe("toHotkeyAccelerator", () => {
+  it("builds accelerator for letter key combinations", () => {
+    expect(
+      toHotkeyAccelerator({
+        key: "k",
+        ctrlKey: true,
+        altKey: false,
+        shiftKey: true,
+        metaKey: false,
+      }),
+    ).toBe("Ctrl+Shift+K");
+  });
+
+  it("maps space key into accelerator syntax", () => {
+    expect(
+      toHotkeyAccelerator({
+        key: " ",
+        ctrlKey: true,
+        altKey: false,
+        shiftKey: true,
+        metaKey: false,
+      }),
+    ).toBe("Ctrl+Shift+Space");
+  });
+
+  it("supports single-key shortcuts", () => {
+    expect(
+      toHotkeyAccelerator({
+        key: "A",
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+        metaKey: false,
+      }),
+    ).toBe("A");
+  });
+
+  it("ignores modifier-only shortcuts", () => {
+    expect(
+      toHotkeyAccelerator({
+        key: "Control",
+        ctrlKey: true,
+        altKey: false,
+        shiftKey: false,
+        metaKey: false,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/features/hotkey-settings/model/constants.ts
+++ b/src/features/hotkey-settings/model/constants.ts
@@ -5,3 +5,27 @@ export const TOGGLE_OVERLAY_INTERACTIVITY_ACTION: HotkeyAction = "toggle_overlay
 
 export const DEFAULT_VISIBILITY_HOTKEY = "Ctrl+Shift+Space";
 export const DEFAULT_INTERACTIVITY_HOTKEY = "Ctrl+Shift+Enter";
+
+export type HotkeySettingItem = {
+  action: HotkeyAction;
+  title: string;
+  description: string;
+};
+
+export const HOTKEY_SETTING_ITEMS: HotkeySettingItem[] = [
+  {
+    action: TOGGLE_OVERLAY_VISIBILITY_ACTION,
+    title: "Toggle overlay visibility",
+    description: "Show or hide the overlay window globally.",
+  },
+  {
+    action: TOGGLE_OVERLAY_INTERACTIVITY_ACTION,
+    title: "Toggle interaction mode",
+    description: "Temporarily switch between click-through and interactive overlay modes.",
+  },
+];
+
+export const HOTKEY_ACTION_LABELS: Record<HotkeyAction, string> = {
+  [TOGGLE_OVERLAY_VISIBILITY_ACTION]: "Overlay visibility",
+  [TOGGLE_OVERLAY_INTERACTIVITY_ACTION]: "Interaction mode",
+};

--- a/src/features/hotkey-settings/model/hotkey-accelerator.ts
+++ b/src/features/hotkey-settings/model/hotkey-accelerator.ts
@@ -1,0 +1,92 @@
+type HotkeyKeyboardEventLike = Pick<
+  KeyboardEvent,
+  "key" | "ctrlKey" | "altKey" | "shiftKey" | "metaKey"
+>;
+
+const MODIFIER_KEYS = new Set(["Control", "Alt", "Shift", "Meta", "Ctrl"]);
+
+const KEY_ALIASES: Record<string, string> = {
+  " ": "Space",
+  Spacebar: "Space",
+  Esc: "Escape",
+  Return: "Enter",
+  Control: "Ctrl",
+  OS: "Meta",
+};
+
+function isModifierKey(key: string): boolean {
+  return MODIFIER_KEYS.has(key);
+}
+
+function normalizeHotkeyKey(key: string): string | null {
+  if (!key) {
+    return null;
+  }
+
+  const alias = KEY_ALIASES[key];
+  if (alias) {
+    return alias;
+  }
+
+  if (key === "Unidentified") {
+    return null;
+  }
+
+  if (/^F\d{1,2}$/i.test(key)) {
+    return key.toUpperCase();
+  }
+
+  if (key.length === 1) {
+    return key.toUpperCase();
+  }
+
+  if (/^Arrow(Up|Down|Left|Right)$/.test(key)) {
+    return key;
+  }
+
+  if (
+    ["Enter", "Tab", "Backspace", "Delete", "Insert", "Home", "End", "PageUp", "PageDown"].includes(
+      key,
+    )
+  ) {
+    return key;
+  }
+
+  return null;
+}
+
+export function toHotkeyAccelerator(event: HotkeyKeyboardEventLike): string | null {
+  const normalizedKey = normalizeHotkeyKey(event.key);
+  if (!normalizedKey) {
+    return null;
+  }
+
+  if (isModifierKey(normalizedKey)) {
+    return null;
+  }
+
+  const ctrlActive = event.ctrlKey;
+  const altActive = event.altKey;
+  const shiftActive = event.shiftKey;
+  const metaActive = event.metaKey;
+
+  const modifiers: string[] = [];
+  if (ctrlActive) {
+    modifiers.push("Ctrl");
+  }
+  if (altActive) {
+    modifiers.push("Alt");
+  }
+  if (shiftActive) {
+    modifiers.push("Shift");
+  }
+  if (metaActive) {
+    modifiers.push("Meta");
+  }
+
+  if (modifiers.length === 0) {
+    return normalizedKey;
+  }
+
+  return [...modifiers, normalizedKey].join("+");
+}

--- a/src/features/hotkey-settings/model/use-hotkey-settings.ts
+++ b/src/features/hotkey-settings/model/use-hotkey-settings.ts
@@ -1,6 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { HotkeyAction } from "@/shared/config/hotkeys";
 import { getHotkeyBindings, updateHotkeyBinding } from "./api";
 import {
+  HOTKEY_ACTION_LABELS,
+  HOTKEY_SETTING_ITEMS,
+  type HotkeySettingItem,
   DEFAULT_INTERACTIVITY_HOTKEY,
   DEFAULT_VISIBILITY_HOTKEY,
   TOGGLE_OVERLAY_INTERACTIVITY_ACTION,
@@ -8,15 +12,25 @@ import {
 } from "./constants";
 import { toErrorMessage } from "@/shared/lib/to-error-message";
 
+type HotkeyBindingsMap = Record<HotkeyAction, string>;
+
+function getDefaultHotkeyBindings(): HotkeyBindingsMap {
+  return {
+    [TOGGLE_OVERLAY_VISIBILITY_ACTION]: DEFAULT_VISIBILITY_HOTKEY,
+    [TOGGLE_OVERLAY_INTERACTIVITY_ACTION]: DEFAULT_INTERACTIVITY_HOTKEY,
+  } as HotkeyBindingsMap;
+}
+
+type HotkeySettingRow = HotkeySettingItem & {
+  accelerator: string;
+};
+
 export function useHotkeySettings(tauriRuntime: boolean) {
-  const [toggleVisibilityHotkey, setToggleVisibilityHotkey] = useState(DEFAULT_VISIBILITY_HOTKEY);
-  const [toggleInteractivityHotkey, setToggleInteractivityHotkey] = useState(
-    DEFAULT_INTERACTIVITY_HOTKEY,
-  );
+  const [hotkeyBindings, setHotkeyBindings] = useState<HotkeyBindingsMap>(getDefaultHotkeyBindings);
   const [hotkeyStatus, setHotkeyStatus] = useState("");
   const [hotkeyError, setHotkeyError] = useState("");
   const [isHotkeysLoading, setIsHotkeysLoading] = useState(false);
-  const [isHotkeySaving, setIsHotkeySaving] = useState(false);
+  const [savingAction, setSavingAction] = useState<HotkeyAction | null>(null);
 
   useEffect(() => {
     if (!tauriRuntime) {
@@ -37,19 +51,12 @@ export function useHotkeySettings(tauriRuntime: boolean) {
           return;
         }
 
-        const visibilityBinding = bindings.find(
-          (binding) => binding.action === TOGGLE_OVERLAY_VISIBILITY_ACTION,
-        );
-        if (visibilityBinding) {
-          setToggleVisibilityHotkey(visibilityBinding.accelerator);
+        const nextBindings = getDefaultHotkeyBindings();
+        for (const binding of bindings) {
+          nextBindings[binding.action] = binding.accelerator.trim();
         }
 
-        const interactivityBinding = bindings.find(
-          (binding) => binding.action === TOGGLE_OVERLAY_INTERACTIVITY_ACTION,
-        );
-        if (interactivityBinding) {
-          setToggleInteractivityHotkey(interactivityBinding.accelerator);
-        }
+        setHotkeyBindings(nextBindings);
       } catch (error) {
         if (!canceled) {
           setHotkeyError(`Failed to load hotkey settings: ${toErrorMessage(error)}`);
@@ -73,53 +80,63 @@ export function useHotkeySettings(tauriRuntime: boolean) {
       return "Open in Tauri desktop runtime to configure hotkeys.";
     }
 
-    return "Overlay is click-through by default. Use the interaction hotkey to unlock UI controls temporarily.";
+    return "Use Change to capture any key or key combination and Clear to disable it. Overlay is click-through by default; use the interaction hotkey to unlock controls temporarily.";
   }, [tauriRuntime]);
 
-  async function saveHotkeys() {
-    if (!tauriRuntime) {
-      setHotkeyError("Hotkey updates are available only in desktop runtime.");
-      return;
-    }
+  const isHotkeySaving = savingAction !== null;
 
-    const nextVisibilityHotkey = toggleVisibilityHotkey.trim();
-    const nextInteractivityHotkey = toggleInteractivityHotkey.trim();
+  const hotkeyRows = useMemo<HotkeySettingRow[]>(() => {
+    return HOTKEY_SETTING_ITEMS.map((item) => ({
+      ...item,
+      accelerator: hotkeyBindings[item.action],
+    }));
+  }, [hotkeyBindings]);
 
-    if (!nextVisibilityHotkey || !nextInteractivityHotkey) {
-      setHotkeyError("Hotkeys cannot be empty.");
-      return;
-    }
+  const updateHotkey = useCallback(
+    async (action: HotkeyAction, accelerator: string) => {
+      if (!tauriRuntime) {
+        setHotkeyError("Hotkey updates are available only in desktop runtime.");
+        return;
+      }
 
-    setIsHotkeySaving(true);
-    setHotkeyError("");
-    setHotkeyStatus("");
+      const nextAccelerator = accelerator.trim();
+      const actionLabel = HOTKEY_ACTION_LABELS[action];
 
-    try {
-      await updateHotkeyBinding(TOGGLE_OVERLAY_VISIBILITY_ACTION, nextVisibilityHotkey);
-      await updateHotkeyBinding(TOGGLE_OVERLAY_INTERACTIVITY_ACTION, nextInteractivityHotkey);
+      setSavingAction(action);
+      setHotkeyError("");
+      setHotkeyStatus("");
 
-      setToggleVisibilityHotkey(nextVisibilityHotkey);
-      setToggleInteractivityHotkey(nextInteractivityHotkey);
-      setHotkeyStatus(
-        `Hotkeys saved: visibility ${nextVisibilityHotkey}, interaction ${nextInteractivityHotkey}`,
-      );
-    } catch (error) {
-      setHotkeyError(`Failed to save hotkey: ${toErrorMessage(error)}`);
-    } finally {
-      setIsHotkeySaving(false);
-    }
-  }
+      try {
+        await updateHotkeyBinding(action, nextAccelerator);
+        setHotkeyBindings((currentBindings) => ({
+          ...currentBindings,
+          [action]: nextAccelerator,
+        }));
+
+        if (nextAccelerator) {
+          setHotkeyStatus(`${actionLabel} hotkey set to ${nextAccelerator}.`);
+        } else {
+          setHotkeyStatus(`${actionLabel} hotkey disabled.`);
+        }
+      } catch (error) {
+        setHotkeyError(
+          `Failed to update ${actionLabel.toLowerCase()} hotkey: ${toErrorMessage(error)}`,
+        );
+      } finally {
+        setSavingAction(null);
+      }
+    },
+    [tauriRuntime],
+  );
 
   return {
+    hotkeyRows,
     hotkeyError,
     hotkeyStatus,
     hotkeySupportHint,
     isHotkeySaving,
     isHotkeysLoading,
-    saveHotkeys,
-    setToggleInteractivityHotkey,
-    setToggleVisibilityHotkey,
-    toggleInteractivityHotkey,
-    toggleVisibilityHotkey,
+    savingAction,
+    updateHotkey,
   };
 }

--- a/src/features/hotkey-settings/ui/hotkey-settings-panel.tsx
+++ b/src/features/hotkey-settings/ui/hotkey-settings-panel.tsx
@@ -1,4 +1,7 @@
+import { useEffect, useState } from "react";
 import { useHotkeySettings } from "@/features/hotkey-settings/model";
+import { toHotkeyAccelerator } from "@/features/hotkey-settings/model/hotkey-accelerator";
+import type { HotkeyAction } from "@/shared/config/hotkeys";
 import { Button } from "@/shared/ui/button";
 
 type Props = {
@@ -7,64 +10,125 @@ type Props = {
 
 export function HotkeySettingsPanel({ tauriRuntime }: Props) {
   const {
+    hotkeyRows,
     hotkeyError,
     hotkeyStatus,
     hotkeySupportHint,
     isHotkeySaving,
     isHotkeysLoading,
-    saveHotkeys,
-    setToggleInteractivityHotkey,
-    setToggleVisibilityHotkey,
-    toggleInteractivityHotkey,
-    toggleVisibilityHotkey,
+    savingAction,
+    updateHotkey,
   } = useHotkeySettings(tauriRuntime);
+  const [capturingAction, setCapturingAction] = useState<HotkeyAction | null>(null);
+  const [captureError, setCaptureError] = useState("");
+
+  useEffect(() => {
+    if (!capturingAction || !tauriRuntime) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (
+        event.key === "Escape" &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.shiftKey &&
+        !event.metaKey
+      ) {
+        setCapturingAction(null);
+        setCaptureError("");
+        return;
+      }
+
+      const accelerator = toHotkeyAccelerator(event);
+      if (!accelerator) {
+        setCaptureError("Use at least one non-modifier key for the hotkey.");
+        return;
+      }
+
+      setCaptureError("");
+      setCapturingAction(null);
+      void updateHotkey(capturingAction, accelerator);
+    };
+
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [capturingAction, tauriRuntime, updateHotkey]);
+
+  const controlsDisabled = !tauriRuntime || isHotkeysLoading || isHotkeySaving;
+
+  function handleCaptureToggle(action: HotkeyAction) {
+    if (capturingAction === action) {
+      setCapturingAction(null);
+      setCaptureError("");
+      return;
+    }
+
+    setCapturingAction(action);
+    setCaptureError("");
+  }
 
   return (
     <section className="rounded-lg border bg-muted/40 p-4 text-sm">
       <p className="font-medium">Hotkeys</p>
       <p className="mt-1 text-muted-foreground">{hotkeySupportHint}</p>
 
-      <div className="mt-4 grid gap-2">
-        <label
-          htmlFor="toggle-overlay-visibility-hotkey"
-          className="text-xs font-medium text-muted-foreground"
-        >
-          Toggle overlay visibility
-        </label>
-        <input
-          id="toggle-overlay-visibility-hotkey"
-          value={toggleVisibilityHotkey}
-          onChange={(event) => setToggleVisibilityHotkey(event.target.value)}
-          placeholder="Ctrl+Shift+Space"
-          disabled={!tauriRuntime || isHotkeysLoading || isHotkeySaving}
-          className="h-9 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
-        />
+      <div className="mt-4 space-y-3">
+        {hotkeyRows.map((hotkeyRow) => {
+          const isCapturing = capturingAction === hotkeyRow.action;
+          const currentValue = hotkeyRow.accelerator || "Not set";
+          const canClear = !controlsDisabled && Boolean(hotkeyRow.accelerator);
 
-        <label
-          htmlFor="toggle-overlay-interaction-hotkey"
-          className="mt-2 text-xs font-medium text-muted-foreground"
-        >
-          Toggle interaction mode
-        </label>
-        <input
-          id="toggle-overlay-interaction-hotkey"
-          value={toggleInteractivityHotkey}
-          onChange={(event) => setToggleInteractivityHotkey(event.target.value)}
-          placeholder="Ctrl+Shift+Enter"
-          disabled={!tauriRuntime || isHotkeysLoading || isHotkeySaving}
-          className="h-9 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
-        />
+          return (
+            <div
+              key={hotkeyRow.action}
+              className="grid gap-3 rounded-lg border border-border/70 bg-background/80 p-3 md:grid-cols-[1fr_auto] md:items-center"
+            >
+              <div>
+                <p className="text-sm font-medium">{hotkeyRow.title}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{hotkeyRow.description}</p>
+              </div>
+
+              <div className="flex flex-wrap items-center justify-start gap-2 md:justify-end">
+                <span className="rounded-md border border-border/70 bg-muted/20 px-3 py-1.5 font-mono text-xs">
+                  {isCapturing ? "Press shortcut..." : currentValue}
+                </span>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={isCapturing ? "secondary" : "outline"}
+                  onClick={() => handleCaptureToggle(hotkeyRow.action)}
+                  disabled={controlsDisabled}
+                >
+                  {isCapturing ? "Cancel" : "Change"}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => void updateHotkey(hotkeyRow.action, "")}
+                  disabled={!canClear}
+                >
+                  Clear
+                </Button>
+              </div>
+            </div>
+          );
+        })}
       </div>
 
-      <div className="mt-3 flex flex-wrap gap-2">
-        <Button
-          onClick={saveHotkeys}
-          disabled={!tauriRuntime || isHotkeysLoading || isHotkeySaving}
-        >
-          {isHotkeySaving ? "Saving..." : "Save hotkey"}
-        </Button>
-      </div>
-
+      {capturingAction ? (
+        <p className="mt-3 text-xs text-muted-foreground">
+          Press a shortcut now. Press Escape to cancel capture.
+        </p>
+      ) : null}
+      {captureError ? <p className="mt-2 text-xs text-destructive">{captureError}</p> : null}
+      {savingAction ? <p className="mt-2 text-xs text-muted-foreground">Saving hotkey...</p> : null}
       {hotkeyStatus ? <p className="mt-3 text-xs text-muted-foreground">{hotkeyStatus}</p> : null}
       {hotkeyError ? <p className="mt-2 text-xs text-destructive">{hotkeyError}</p> : null}
     </section>

--- a/src/features/settings-modal/ui/settings-modal-content.tsx
+++ b/src/features/settings-modal/ui/settings-modal-content.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { SettingsSection } from "@/features/settings-modal/model";
 import { TabsContent } from "@/shared/ui/tabs";
 import { SettingsCategoryPlaceholder } from "./settings-category-placeholder";
@@ -5,15 +6,16 @@ import { ScrollArea } from "@/shared/ui/scroll-area";
 
 type Props = {
   sections: SettingsSection[];
+  sectionContent?: Partial<Record<SettingsSection["id"], ReactNode>>;
 };
 
-export function SettingsModalContent({ sections }: Props) {
+export function SettingsModalContent({ sections, sectionContent }: Props) {
   return (
     <ScrollArea className="min-h-0 flex-1">
       <div className="p-4">
         {sections.map((section) => (
           <TabsContent key={section.id} value={section.id} className="m-0 h-full">
-            <SettingsCategoryPlaceholder section={section} />
+            {sectionContent?.[section.id] ?? <SettingsCategoryPlaceholder section={section} />}
           </TabsContent>
         ))}
       </div>

--- a/src/features/settings-modal/ui/settings-modal.tsx
+++ b/src/features/settings-modal/ui/settings-modal.tsx
@@ -1,4 +1,5 @@
-import { settingsSections } from "@/features/settings-modal/model";
+import type { ReactNode } from "react";
+import { settingsSections, type SettingsSectionId } from "@/features/settings-modal/model";
 import { SettingsModalContent } from "@/features/settings-modal/ui/settings-modal-content";
 import { SettingsModalSidebar } from "@/features/settings-modal/ui/settings-modal-sidebar";
 import { Button } from "@/shared/ui/button";
@@ -15,9 +16,10 @@ import { Tabs } from "@/shared/ui/tabs";
 type Props = {
   open: boolean;
   onClose: () => void;
+  sectionContent?: Partial<Record<SettingsSectionId, ReactNode>>;
 };
 
-export function SettingsModal({ open, onClose }: Props) {
+export function SettingsModal({ open, onClose, sectionContent }: Props) {
   return (
     <Dialog
       open={open}
@@ -51,7 +53,7 @@ export function SettingsModal({ open, onClose }: Props) {
           className="flex min-h-0 flex-1 flex-row"
         >
           <SettingsModalSidebar sections={settingsSections} />
-          <SettingsModalContent sections={settingsSections} />
+          <SettingsModalContent sections={settingsSections} sectionContent={sectionContent} />
         </Tabs>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary

Implemented full Hotkeys settings so users can configure shortcuts directly in-app instead of using placeholders.  
This adds per-action hotkey rows with keyboard capture, supports single-key and combo shortcuts, and allows disabling a hotkey via `Clear`.  
Backend hotkey update logic was adjusted to accept empty accelerators as a valid “disabled” state, keeping UI and runtime behavior consistent.

## Scope

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Infrastructure / CI
- [x] Documentation

## Why now

The Hotkeys tab existed but had no real functionality, so users could not customize bindings.  
This PR enables real shortcut management for the two primary overlay actions (visibility and interaction mode), including quick reassignment and explicit disable behavior.

## Validation

How was this verified?

- [ ] `npm run check` (blocked by pre-existing formatting issues in unrelated files from updated `main`)
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [ ] Manual verification (if applicable)

Additional verification performed:
- Frontend hotkey parser tests (`vitest`) pass.
- Backend hotkey validation tests (`cargo test` for hotkey service tests) pass.

## Risks

- Hotkey bindings are still runtime-only (not persisted across app restarts yet).
- Modifier-only shortcuts (e.g. `Ctrl` alone) are not supported by Tauri’s parser; users must include a non-modifier key.
- Single-key global shortcuts can conflict more easily with other apps/system shortcuts.

## Documentation

- [ ] Docs updated
- [x] `CHANGELOG.md` updated for user-facing changes
- [ ] Internal-only change: used `[skip-changelog]` in PR title/body with rationale
- [ ] Docs not needed (explain in Summary)

## Before requesting review

- [x] Local checks pass
- [x] CI is green