### PR TITLE
fix: preserve interaction mode on overlay hide/show toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Write entries from user impact first, then technical detail.
 - Overlay window now runs in passive click-through mode by default and switches to interactive mode only when toggled by hotkey or UI action.
 - Overlay shell now uses a transparent, compact window that tracks content size instead of relying on a large fullscreen transparent surface.
 - Settings modal backdrop now respects the overlay panel rounded corners instead of rendering a square dimming layer.
+- Overlay hide/show now preserves the current interaction mode, so showing the window no longer forces click-through after it was interactive before hiding.
 
 ### Removed
 

--- a/src-tauri/src/features/overlay/service.rs
+++ b/src-tauri/src/features/overlay/service.rs
@@ -50,10 +50,6 @@ pub fn toggle_overlay_visibility(app: &AppHandle) -> Result<(), String> {
         .map_err(|error| format!("failed to read overlay visibility: {error}"))?;
 
     if is_visible {
-        if let Err(error) = set_overlay_interaction_enabled(app, false) {
-            eprintln!("failed to lock overlay interaction before hide: {error}");
-        }
-
         window
             .hide()
             .map_err(|error| format!("failed to hide overlay window: {error}"))?;


### PR DESCRIPTION
## Summary

Исправлен баг с потерей режима интерактивности оверлея при `hide/show` (по хоткею видимости).  
Раньше при скрытии окно принудительно переводилось в `click-through`, из-за чего после `show` состояние всегда сбрасывалось. Теперь режим взаимодействия сохраняется и при показе восстанавливается в том же состоянии, что было до скрытия.

## Scope

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Infrastructure / CI
- [x] Documentation

## Why now

Сейчас пользователь теряет выбранный режим (interactive vs click-through) после скрытия/показа оверлея, что ломает ожидаемое поведение и ухудшает UX.  
Фикс делает поведение предсказуемым: `hide/show` больше не меняет режим взаимодействия сам по себе.

## Validation

How was this verified?

- [ ] `npm run check` (падает на format-check в файлах вне scope задачи: `.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/ci.yml`, `.github/workflows/release-beta.yml`, `CONTRIBUTING.md`, `README.md`, `RELEASE_CHECKLIST.md`)
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml` (не запускался, т.к. по протоколу остановились после падения `npm run check`)
- [ ] Manual verification (if applicable)

## Risks

Фикс адресует только сценарий `hide/show` через hotkey toggle visibility.  
Потенциально отдельная проверка нужна для других путей изменения состояния окна (например, системные window-state события, если будут добавлены позже).

## Documentation

- [ ] Docs updated
- [x] `CHANGELOG.md` updated for user-facing changes
- [ ] Internal-only change: used `[skip-changelog]` in PR title/body with rationale
- [x] Docs not needed (explain in Summary)

## Before requesting review

- [ ] Local checks pass
- [ ] CI is green