### PR TITLE
feat(providers): add static provider catalog with model metadata

### DIFF
--- a/src-tauri/src/app/bootstrap.rs
+++ b/src-tauri/src/app/bootstrap.rs
@@ -33,6 +33,7 @@ pub fn run() {
             commands::get_overlay_interaction_enabled,
             commands::set_overlay_interaction_enabled_command,
             commands::toggle_overlay_interaction_enabled_command,
+            commands::list_provider_catalog,
             commands::get_provider_settings,
             commands::save_provider_settings,
             commands::remove_provider_credentials,

--- a/src-tauri/src/app/commands.rs
+++ b/src-tauri/src/app/commands.rs
@@ -3,6 +3,7 @@ use tauri::{AppHandle, State};
 use crate::features::hotkeys::model::{HotkeyAction, HotkeyBinding};
 use crate::features::hotkeys::state::HotkeyBindingsState;
 use crate::features::overlay::state::OverlayRuntimeState;
+use crate::features::providers::catalog::ProviderCatalog;
 use crate::features::providers::model::{
     ChatMessageInput, ChatMessageResponse, ProviderSettingsInput, ProviderSettingsView,
 };
@@ -38,6 +39,11 @@ pub fn set_overlay_interaction_enabled_command(
 #[tauri::command]
 pub fn toggle_overlay_interaction_enabled_command(app: AppHandle) -> Result<bool, String> {
     crate::features::overlay::commands::toggle_overlay_interaction_enabled_command(app)
+}
+
+#[tauri::command]
+pub fn list_provider_catalog() -> ProviderCatalog {
+    crate::features::providers::commands::list_provider_catalog()
 }
 
 #[tauri::command]

--- a/src-tauri/src/features/providers/catalog.json
+++ b/src-tauri/src/features/providers/catalog.json
@@ -1,0 +1,796 @@
+{
+  "version": 1,
+  "providers": [
+    {
+      "id": "openai",
+      "name": "OpenAI",
+      "protocol": "openai",
+      "defaultBaseUrl": "https://api.openai.com/v1",
+      "auth": "api_key",
+      "apiKeyEnv": "OPENAI_API_KEY",
+      "docsUrl": "https://platform.openai.com/docs",
+      "description": "Official OpenAI hosted models.",
+      "allowsCustomModels": true,
+      "models": [
+        {
+          "id": "gpt-4o",
+          "name": "GPT-4o",
+          "contextWindow": 128000,
+          "maxOutputTokens": 16384,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": true },
+          "knowledgeCutoff": "2024-10"
+        },
+        {
+          "id": "gpt-4o-mini",
+          "name": "GPT-4o mini",
+          "contextWindow": 128000,
+          "maxOutputTokens": 16384,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": false },
+          "knowledgeCutoff": "2024-10",
+          "default": true
+        },
+        {
+          "id": "gpt-4.1",
+          "name": "GPT-4.1",
+          "contextWindow": 1047576,
+          "maxOutputTokens": 32768,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "gpt-4.1-mini",
+          "name": "GPT-4.1 mini",
+          "contextWindow": 1047576,
+          "maxOutputTokens": 32768,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "gpt-4.1-nano",
+          "name": "GPT-4.1 nano",
+          "contextWindow": 1047576,
+          "maxOutputTokens": 32768,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "o3",
+          "name": "o3",
+          "contextWindow": 200000,
+          "maxOutputTokens": 100000,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "o3-mini",
+          "name": "o3-mini",
+          "contextWindow": 200000,
+          "maxOutputTokens": 100000,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "o1",
+          "name": "o1",
+          "contextWindow": 200000,
+          "maxOutputTokens": 100000,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "o1-mini",
+          "name": "o1-mini",
+          "contextWindow": 128000,
+          "maxOutputTokens": 65536,
+          "capabilities": { "vision": false, "toolCalls": false, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "gpt-4-turbo",
+          "name": "GPT-4 Turbo",
+          "contextWindow": 128000,
+          "maxOutputTokens": 4096,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": false }
+        }
+      ]
+    },
+    {
+      "id": "anthropic",
+      "name": "Anthropic",
+      "protocol": "anthropic",
+      "defaultBaseUrl": "https://api.anthropic.com/v1",
+      "auth": "api_key",
+      "apiKeyEnv": "ANTHROPIC_API_KEY",
+      "docsUrl": "https://docs.anthropic.com",
+      "description": "Anthropic Claude models via the Messages API.",
+      "allowsCustomModels": true,
+      "models": [
+        {
+          "id": "claude-opus-4-7",
+          "name": "Claude Opus 4.7",
+          "contextWindow": 200000,
+          "maxOutputTokens": 32000,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": false },
+          "default": true
+        },
+        {
+          "id": "claude-sonnet-4-6",
+          "name": "Claude Sonnet 4.6",
+          "contextWindow": 200000,
+          "maxOutputTokens": 64000,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "claude-haiku-4-5-20251001",
+          "name": "Claude Haiku 4.5",
+          "contextWindow": 200000,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "claude-3-7-sonnet-20250219",
+          "name": "Claude 3.7 Sonnet",
+          "contextWindow": 200000,
+          "maxOutputTokens": 64000,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "claude-3-5-sonnet-20241022",
+          "name": "Claude 3.5 Sonnet",
+          "contextWindow": 200000,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "claude-3-5-haiku-20241022",
+          "name": "Claude 3.5 Haiku",
+          "contextWindow": 200000,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "claude-3-opus-20240229",
+          "name": "Claude 3 Opus",
+          "contextWindow": 200000,
+          "maxOutputTokens": 4096,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": false }
+        }
+      ]
+    },
+    {
+      "id": "google",
+      "name": "Google Gemini",
+      "protocol": "gemini",
+      "defaultBaseUrl": "https://generativelanguage.googleapis.com/v1beta",
+      "auth": "api_key",
+      "apiKeyEnv": "GOOGLE_API_KEY",
+      "docsUrl": "https://ai.google.dev/gemini-api/docs",
+      "description": "Google Gemini models via the Generative Language API.",
+      "allowsCustomModels": true,
+      "models": [
+        {
+          "id": "gemini-2.5-pro",
+          "name": "Gemini 2.5 Pro",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 65536,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": true },
+          "default": true
+        },
+        {
+          "id": "gemini-2.5-flash",
+          "name": "Gemini 2.5 Flash",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 65536,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": true }
+        },
+        {
+          "id": "gemini-2.5-flash-lite",
+          "name": "Gemini 2.5 Flash Lite",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 65536,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": true }
+        },
+        {
+          "id": "gemini-2.0-flash",
+          "name": "Gemini 2.0 Flash",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": true }
+        },
+        {
+          "id": "gemini-2.0-flash-thinking-exp",
+          "name": "Gemini 2.0 Flash Thinking",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 65536,
+          "capabilities": { "vision": true, "toolCalls": false, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "gemini-1.5-pro",
+          "name": "Gemini 1.5 Pro",
+          "contextWindow": 2097152,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": true }
+        },
+        {
+          "id": "gemini-1.5-flash",
+          "name": "Gemini 1.5 Flash",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": true }
+        }
+      ]
+    },
+    {
+      "id": "xai",
+      "name": "xAI Grok",
+      "protocol": "openai",
+      "defaultBaseUrl": "https://api.x.ai/v1",
+      "auth": "api_key",
+      "apiKeyEnv": "XAI_API_KEY",
+      "docsUrl": "https://docs.x.ai",
+      "description": "xAI Grok family via OpenAI-compatible API.",
+      "allowsCustomModels": true,
+      "models": [
+        {
+          "id": "grok-4",
+          "name": "Grok 4",
+          "contextWindow": 256000,
+          "maxOutputTokens": 16384,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": false },
+          "default": true
+        },
+        {
+          "id": "grok-4-fast-reasoning",
+          "name": "Grok 4 Fast (reasoning)",
+          "contextWindow": 2000000,
+          "maxOutputTokens": 16384,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "grok-4-fast-non-reasoning",
+          "name": "Grok 4 Fast",
+          "contextWindow": 2000000,
+          "maxOutputTokens": 16384,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "grok-3",
+          "name": "Grok 3",
+          "contextWindow": 131072,
+          "maxOutputTokens": 16384,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "grok-3-mini",
+          "name": "Grok 3 Mini",
+          "contextWindow": 131072,
+          "maxOutputTokens": 16384,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "grok-2-vision-1212",
+          "name": "Grok 2 Vision",
+          "contextWindow": 32768,
+          "maxOutputTokens": 4096,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": false }
+        }
+      ]
+    },
+    {
+      "id": "deepseek",
+      "name": "DeepSeek",
+      "protocol": "openai",
+      "defaultBaseUrl": "https://api.deepseek.com",
+      "auth": "api_key",
+      "apiKeyEnv": "DEEPSEEK_API_KEY",
+      "docsUrl": "https://api-docs.deepseek.com",
+      "description": "DeepSeek chat and reasoning models.",
+      "allowsCustomModels": true,
+      "models": [
+        {
+          "id": "deepseek-chat",
+          "name": "DeepSeek V3 Chat",
+          "contextWindow": 64000,
+          "maxOutputTokens": 8192,
+          "capabilities": {
+            "vision": false,
+            "toolCalls": true,
+            "reasoning": false,
+            "audio": false
+          },
+          "default": true
+        },
+        {
+          "id": "deepseek-reasoner",
+          "name": "DeepSeek R1 Reasoner",
+          "contextWindow": 64000,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": false, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "deepseek-coder",
+          "name": "DeepSeek Coder",
+          "contextWindow": 64000,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        }
+      ]
+    },
+    {
+      "id": "mistral",
+      "name": "Mistral AI",
+      "protocol": "openai",
+      "defaultBaseUrl": "https://api.mistral.ai/v1",
+      "auth": "api_key",
+      "apiKeyEnv": "MISTRAL_API_KEY",
+      "docsUrl": "https://docs.mistral.ai",
+      "description": "Mistral hosted models via OpenAI-compatible API.",
+      "allowsCustomModels": true,
+      "models": [
+        {
+          "id": "mistral-large-latest",
+          "name": "Mistral Large",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": {
+            "vision": false,
+            "toolCalls": true,
+            "reasoning": false,
+            "audio": false
+          },
+          "default": true
+        },
+        {
+          "id": "mistral-medium-latest",
+          "name": "Mistral Medium",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "mistral-small-latest",
+          "name": "Mistral Small",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "codestral-latest",
+          "name": "Codestral",
+          "contextWindow": 262144,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "pixtral-large-latest",
+          "name": "Pixtral Large",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "ministral-8b-latest",
+          "name": "Ministral 8B",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        }
+      ]
+    },
+    {
+      "id": "groq",
+      "name": "Groq",
+      "protocol": "openai",
+      "defaultBaseUrl": "https://api.groq.com/openai/v1",
+      "auth": "api_key",
+      "apiKeyEnv": "GROQ_API_KEY",
+      "docsUrl": "https://console.groq.com/docs",
+      "description": "Low-latency inference for open models on Groq LPU.",
+      "allowsCustomModels": true,
+      "models": [
+        {
+          "id": "llama-3.3-70b-versatile",
+          "name": "Llama 3.3 70B Versatile",
+          "contextWindow": 131072,
+          "maxOutputTokens": 32768,
+          "capabilities": {
+            "vision": false,
+            "toolCalls": true,
+            "reasoning": false,
+            "audio": false
+          },
+          "default": true
+        },
+        {
+          "id": "llama-3.1-8b-instant",
+          "name": "Llama 3.1 8B Instant",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "deepseek-r1-distill-llama-70b",
+          "name": "DeepSeek R1 Distill Llama 70B",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": false, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "mixtral-8x7b-32768",
+          "name": "Mixtral 8x7B",
+          "contextWindow": 32768,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "gemma2-9b-it",
+          "name": "Gemma 2 9B IT",
+          "contextWindow": 8192,
+          "maxOutputTokens": 8192,
+          "capabilities": {
+            "vision": false,
+            "toolCalls": false,
+            "reasoning": false,
+            "audio": false
+          }
+        }
+      ]
+    },
+    {
+      "id": "openrouter",
+      "name": "OpenRouter",
+      "protocol": "openai",
+      "defaultBaseUrl": "https://openrouter.ai/api/v1",
+      "auth": "api_key",
+      "apiKeyEnv": "OPENROUTER_API_KEY",
+      "docsUrl": "https://openrouter.ai/docs",
+      "description": "Unified gateway for hosted models from many providers.",
+      "allowsCustomModels": true,
+      "models": [
+        {
+          "id": "anthropic/claude-opus-4-7",
+          "name": "Claude Opus 4.7 (OpenRouter)",
+          "contextWindow": 200000,
+          "maxOutputTokens": 32000,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": false },
+          "default": true
+        },
+        {
+          "id": "anthropic/claude-sonnet-4-6",
+          "name": "Claude Sonnet 4.6 (OpenRouter)",
+          "contextWindow": 200000,
+          "maxOutputTokens": 64000,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "anthropic/claude-haiku-4-5",
+          "name": "Claude Haiku 4.5 (OpenRouter)",
+          "contextWindow": 200000,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "openai/gpt-4o",
+          "name": "GPT-4o (OpenRouter)",
+          "contextWindow": 128000,
+          "maxOutputTokens": 16384,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "openai/gpt-4.1",
+          "name": "GPT-4.1 (OpenRouter)",
+          "contextWindow": 1047576,
+          "maxOutputTokens": 32768,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "openai/o3",
+          "name": "o3 (OpenRouter)",
+          "contextWindow": 200000,
+          "maxOutputTokens": 100000,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "openai/o3-mini",
+          "name": "o3-mini (OpenRouter)",
+          "contextWindow": 200000,
+          "maxOutputTokens": 100000,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "google/gemini-2.5-pro",
+          "name": "Gemini 2.5 Pro (OpenRouter)",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 65536,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "google/gemini-2.5-flash",
+          "name": "Gemini 2.5 Flash (OpenRouter)",
+          "contextWindow": 1048576,
+          "maxOutputTokens": 65536,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "x-ai/grok-4",
+          "name": "Grok 4 (OpenRouter)",
+          "contextWindow": 256000,
+          "maxOutputTokens": 16384,
+          "capabilities": { "vision": true, "toolCalls": true, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "deepseek/deepseek-chat",
+          "name": "DeepSeek V3 (OpenRouter)",
+          "contextWindow": 64000,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "deepseek/deepseek-r1",
+          "name": "DeepSeek R1 (OpenRouter)",
+          "contextWindow": 64000,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": false, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "meta-llama/llama-3.3-70b-instruct",
+          "name": "Llama 3.3 70B (OpenRouter)",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "mistralai/mistral-large",
+          "name": "Mistral Large (OpenRouter)",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "qwen/qwen-2.5-coder-32b-instruct",
+          "name": "Qwen 2.5 Coder 32B (OpenRouter)",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        }
+      ]
+    },
+    {
+      "id": "together",
+      "name": "Together AI",
+      "protocol": "openai",
+      "defaultBaseUrl": "https://api.together.xyz/v1",
+      "auth": "api_key",
+      "apiKeyEnv": "TOGETHER_API_KEY",
+      "docsUrl": "https://docs.together.ai",
+      "description": "Open-weight models hosted on Together inference.",
+      "allowsCustomModels": true,
+      "models": [
+        {
+          "id": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+          "name": "Llama 3.3 70B Instruct Turbo",
+          "contextWindow": 131072,
+          "maxOutputTokens": 4096,
+          "capabilities": {
+            "vision": false,
+            "toolCalls": true,
+            "reasoning": false,
+            "audio": false
+          },
+          "default": true
+        },
+        {
+          "id": "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
+          "name": "Llama 3.1 405B Instruct Turbo",
+          "contextWindow": 131072,
+          "maxOutputTokens": 4096,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "Qwen/Qwen2.5-72B-Instruct-Turbo",
+          "name": "Qwen 2.5 72B Instruct Turbo",
+          "contextWindow": 131072,
+          "maxOutputTokens": 4096,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "Qwen/Qwen2.5-Coder-32B-Instruct",
+          "name": "Qwen 2.5 Coder 32B",
+          "contextWindow": 131072,
+          "maxOutputTokens": 4096,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "deepseek-ai/DeepSeek-V3",
+          "name": "DeepSeek V3",
+          "contextWindow": 131072,
+          "maxOutputTokens": 4096,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "deepseek-ai/DeepSeek-R1",
+          "name": "DeepSeek R1",
+          "contextWindow": 131072,
+          "maxOutputTokens": 4096,
+          "capabilities": { "vision": false, "toolCalls": false, "reasoning": true, "audio": false }
+        }
+      ]
+    },
+    {
+      "id": "fireworks",
+      "name": "Fireworks AI",
+      "protocol": "openai",
+      "defaultBaseUrl": "https://api.fireworks.ai/inference/v1",
+      "auth": "api_key",
+      "apiKeyEnv": "FIREWORKS_API_KEY",
+      "docsUrl": "https://docs.fireworks.ai",
+      "description": "Fast inference for open-weight models on Fireworks.",
+      "allowsCustomModels": true,
+      "models": [
+        {
+          "id": "accounts/fireworks/models/llama-v3p3-70b-instruct",
+          "name": "Llama 3.3 70B Instruct",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": {
+            "vision": false,
+            "toolCalls": true,
+            "reasoning": false,
+            "audio": false
+          },
+          "default": true
+        },
+        {
+          "id": "accounts/fireworks/models/llama-v3p1-405b-instruct",
+          "name": "Llama 3.1 405B Instruct",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "accounts/fireworks/models/deepseek-v3",
+          "name": "DeepSeek V3",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "accounts/fireworks/models/deepseek-r1",
+          "name": "DeepSeek R1",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": false, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "accounts/fireworks/models/qwen2p5-coder-32b-instruct",
+          "name": "Qwen 2.5 Coder 32B",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        }
+      ]
+    },
+    {
+      "id": "cerebras",
+      "name": "Cerebras",
+      "protocol": "openai",
+      "defaultBaseUrl": "https://api.cerebras.ai/v1",
+      "auth": "api_key",
+      "apiKeyEnv": "CEREBRAS_API_KEY",
+      "docsUrl": "https://inference-docs.cerebras.ai",
+      "description": "Ultra-fast wafer-scale inference for open models.",
+      "allowsCustomModels": true,
+      "models": [
+        {
+          "id": "llama-3.3-70b",
+          "name": "Llama 3.3 70B",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": {
+            "vision": false,
+            "toolCalls": true,
+            "reasoning": false,
+            "audio": false
+          },
+          "default": true
+        },
+        {
+          "id": "llama3.1-8b",
+          "name": "Llama 3.1 8B",
+          "contextWindow": 8192,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "llama-4-scout-17b-16e-instruct",
+          "name": "Llama 4 Scout 17B 16E",
+          "contextWindow": 131072,
+          "maxOutputTokens": 8192,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        }
+      ]
+    },
+    {
+      "id": "ollama",
+      "name": "Ollama",
+      "protocol": "openai",
+      "defaultBaseUrl": "http://localhost:11434/v1",
+      "auth": "none",
+      "docsUrl": "https://github.com/ollama/ollama",
+      "description": "Local OpenAI-compatible endpoint. Pull the model in Ollama first.",
+      "allowsCustomModels": true,
+      "models": [
+        {
+          "id": "llama3.2",
+          "name": "Llama 3.2",
+          "contextWindow": 131072,
+          "maxOutputTokens": 4096,
+          "capabilities": {
+            "vision": false,
+            "toolCalls": true,
+            "reasoning": false,
+            "audio": false
+          },
+          "default": true
+        },
+        {
+          "id": "llama3.1",
+          "name": "Llama 3.1",
+          "contextWindow": 131072,
+          "maxOutputTokens": 4096,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "qwen2.5-coder",
+          "name": "Qwen 2.5 Coder",
+          "contextWindow": 32768,
+          "maxOutputTokens": 4096,
+          "capabilities": { "vision": false, "toolCalls": true, "reasoning": false, "audio": false }
+        },
+        {
+          "id": "deepseek-r1",
+          "name": "DeepSeek R1",
+          "contextWindow": 32768,
+          "maxOutputTokens": 4096,
+          "capabilities": { "vision": false, "toolCalls": false, "reasoning": true, "audio": false }
+        },
+        {
+          "id": "gemma2",
+          "name": "Gemma 2",
+          "contextWindow": 8192,
+          "maxOutputTokens": 4096,
+          "capabilities": {
+            "vision": false,
+            "toolCalls": false,
+            "reasoning": false,
+            "audio": false
+          }
+        }
+      ]
+    },
+    {
+      "id": "lmstudio",
+      "name": "LM Studio",
+      "protocol": "openai",
+      "defaultBaseUrl": "http://localhost:1234/v1",
+      "auth": "none",
+      "docsUrl": "https://lmstudio.ai/docs",
+      "description": "Local OpenAI-compatible server. Load a model in LM Studio first.",
+      "allowsCustomModels": true,
+      "models": []
+    },
+    {
+      "id": "custom-openai",
+      "name": "Custom OpenAI-compatible",
+      "protocol": "openai",
+      "defaultBaseUrl": "https://example.com/v1",
+      "auth": "api_key",
+      "description": "Any OpenAI-compatible /chat/completions endpoint.",
+      "allowsCustomModels": true,
+      "models": []
+    },
+    {
+      "id": "custom-anthropic",
+      "name": "Custom Anthropic-compatible",
+      "protocol": "anthropic",
+      "defaultBaseUrl": "https://example.com",
+      "auth": "api_key",
+      "description": "Any Anthropic-compatible /v1/messages endpoint.",
+      "allowsCustomModels": true,
+      "models": []
+    }
+  ]
+}

--- a/src-tauri/src/features/providers/catalog.rs
+++ b/src-tauri/src/features/providers/catalog.rs
@@ -1,0 +1,197 @@
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+
+const CATALOG_SOURCE: &str = include_str!("catalog.json");
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderCatalog {
+    pub version: u32,
+    pub providers: Vec<ProviderCatalogEntry>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderCatalogEntry {
+    pub id: String,
+    pub name: String,
+    pub protocol: ProviderProtocol,
+    pub default_base_url: String,
+    pub auth: ProviderAuth,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key_env: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub docs_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub allows_custom_models: bool,
+    #[serde(default)]
+    pub models: Vec<CatalogModel>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ProviderProtocol {
+    Openai,
+    Anthropic,
+    Gemini,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderAuth {
+    ApiKey,
+    None,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogModel {
+    pub id: String,
+    pub name: String,
+    pub context_window: u32,
+    pub max_output_tokens: u32,
+    pub capabilities: ModelCapabilities,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub knowledge_cutoff: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub default: bool,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub deprecated: bool,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelCapabilities {
+    #[serde(default)]
+    pub vision: bool,
+    #[serde(default)]
+    pub tool_calls: bool,
+    #[serde(default)]
+    pub reasoning: bool,
+    #[serde(default)]
+    pub audio: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+static CATALOG: OnceLock<ProviderCatalog> = OnceLock::new();
+
+fn parse_catalog() -> ProviderCatalog {
+    serde_json::from_str::<ProviderCatalog>(CATALOG_SOURCE)
+        .expect("provider catalog must be valid JSON; this is a build-time invariant")
+}
+
+pub fn catalog() -> &'static ProviderCatalog {
+    CATALOG.get_or_init(parse_catalog)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn catalog_parses() {
+        let catalog = catalog();
+        assert_eq!(catalog.version, 1);
+        assert!(
+            catalog.providers.len() >= 10,
+            "expected a detailed catalog, got {} providers",
+            catalog.providers.len()
+        );
+    }
+
+    #[test]
+    fn provider_ids_are_unique_and_normalized() {
+        let mut seen = HashSet::new();
+        for provider in &catalog().providers {
+            assert!(
+                provider
+                    .id
+                    .chars()
+                    .all(|character| character.is_ascii_lowercase()
+                        || character.is_ascii_digit()
+                        || character == '-'
+                        || character == '_'),
+                "provider id '{}' must be lowercase ascii with -/_ only",
+                provider.id
+            );
+            assert!(
+                seen.insert(provider.id.clone()),
+                "duplicate provider id '{}'",
+                provider.id
+            );
+        }
+    }
+
+    #[test]
+    fn provider_base_urls_are_well_formed() {
+        for provider in &catalog().providers {
+            let base = &provider.default_base_url;
+            assert!(
+                base.starts_with("https://")
+                    || base.starts_with("http://localhost")
+                    || base.starts_with("http://127.0.0.1"),
+                "provider '{}' base url '{}' must be https or local http",
+                provider.id,
+                base
+            );
+        }
+    }
+
+    #[test]
+    fn at_most_one_default_per_provider() {
+        for provider in &catalog().providers {
+            let defaults = provider.models.iter().filter(|model| model.default).count();
+            assert!(
+                defaults <= 1,
+                "provider '{}' has {} default models, expected at most 1",
+                provider.id,
+                defaults
+            );
+        }
+    }
+
+    #[test]
+    fn model_ids_within_provider_are_unique() {
+        for provider in &catalog().providers {
+            let mut seen = HashSet::new();
+            for model in &provider.models {
+                assert!(
+                    seen.insert(model.id.clone()),
+                    "provider '{}' has duplicate model id '{}'",
+                    provider.id,
+                    model.id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn expected_providers_present() {
+        let ids: HashSet<&str> = catalog()
+            .providers
+            .iter()
+            .map(|provider| provider.id.as_str())
+            .collect();
+        for expected in [
+            "openai",
+            "anthropic",
+            "google",
+            "openrouter",
+            "ollama",
+            "custom-openai",
+            "custom-anthropic",
+        ] {
+            assert!(
+                ids.contains(expected),
+                "missing expected provider '{expected}'"
+            );
+        }
+    }
+}

--- a/src-tauri/src/features/providers/commands.rs
+++ b/src-tauri/src/features/providers/commands.rs
@@ -1,9 +1,14 @@
 use tauri::AppHandle;
 
+use crate::features::providers::catalog::{self, ProviderCatalog};
 use crate::features::providers::model::{
     ChatMessageInput, ChatMessageResponse, ProviderSettingsInput, ProviderSettingsView,
 };
 use crate::features::providers::service;
+
+pub fn list_provider_catalog() -> ProviderCatalog {
+    catalog::catalog().clone()
+}
 
 pub fn get_provider_settings(app: AppHandle) -> Result<Option<ProviderSettingsView>, String> {
     service::get_provider_settings(&app)

--- a/src-tauri/src/features/providers/mod.rs
+++ b/src-tauri/src/features/providers/mod.rs
@@ -1,3 +1,4 @@
+pub mod catalog;
 pub mod commands;
 pub mod credentials;
 pub mod model;

--- a/src/shared/lib/__tests__/provider-catalog.test.ts
+++ b/src/shared/lib/__tests__/provider-catalog.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchProviderCatalog,
+  findCatalogModel,
+  findCatalogProvider,
+  getDefaultModel,
+  type ProviderCatalog,
+} from "@/shared/lib/providers";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+
+const sampleCatalog: ProviderCatalog = {
+  version: 1,
+  providers: [
+    {
+      id: "openai",
+      name: "OpenAI",
+      protocol: "openai",
+      defaultBaseUrl: "https://api.openai.com/v1",
+      auth: "api_key",
+      allowsCustomModels: true,
+      models: [
+        {
+          id: "gpt-4o-mini",
+          name: "GPT-4o mini",
+          contextWindow: 128000,
+          maxOutputTokens: 16384,
+          capabilities: { vision: true, toolCalls: true, reasoning: false, audio: false },
+          default: true,
+        },
+        {
+          id: "gpt-4o",
+          name: "GPT-4o",
+          contextWindow: 128000,
+          maxOutputTokens: 16384,
+          capabilities: { vision: true, toolCalls: true, reasoning: false, audio: true },
+        },
+      ],
+    },
+  ],
+};
+
+describe("provider catalog helpers", () => {
+  it("findCatalogProvider returns the matching entry", () => {
+    expect(findCatalogProvider(sampleCatalog, "openai")?.name).toBe("OpenAI");
+    expect(findCatalogProvider(sampleCatalog, "missing")).toBeUndefined();
+    expect(findCatalogProvider(undefined, "openai")).toBeUndefined();
+  });
+
+  it("findCatalogModel locates a model inside a provider", () => {
+    const provider = findCatalogProvider(sampleCatalog, "openai");
+    expect(findCatalogModel(provider, "gpt-4o")?.name).toBe("GPT-4o");
+    expect(findCatalogModel(provider, "missing")).toBeUndefined();
+    expect(findCatalogModel(undefined, "gpt-4o")).toBeUndefined();
+  });
+
+  it("getDefaultModel prefers the flagged default, otherwise the first model", () => {
+    const provider = findCatalogProvider(sampleCatalog, "openai");
+    expect(getDefaultModel(provider)?.id).toBe("gpt-4o-mini");
+
+    const providerWithoutFlag = {
+      ...provider!,
+      models: provider!.models.map((model) => ({ ...model, default: false })),
+    };
+    expect(getDefaultModel(providerWithoutFlag)?.id).toBe("gpt-4o-mini");
+
+    const providerWithoutModels = { ...provider!, models: [] };
+    expect(getDefaultModel(providerWithoutModels)).toBeUndefined();
+    expect(getDefaultModel(undefined)).toBeUndefined();
+  });
+
+  it("fetchProviderCatalog forwards the Tauri invoke result", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce(sampleCatalog);
+    await expect(fetchProviderCatalog()).resolves.toEqual(sampleCatalog);
+    expect(invoke).toHaveBeenCalledWith("list_provider_catalog");
+  });
+});

--- a/src/shared/lib/providers/catalog.ts
+++ b/src/shared/lib/providers/catalog.ts
@@ -1,0 +1,80 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useQuery } from "@tanstack/react-query";
+
+export type ProviderProtocol = "openai" | "anthropic" | "gemini";
+export type ProviderAuth = "api_key" | "none";
+
+export type ModelCapabilities = {
+  vision: boolean;
+  toolCalls: boolean;
+  reasoning: boolean;
+  audio: boolean;
+};
+
+export type CatalogModel = {
+  id: string;
+  name: string;
+  contextWindow: number;
+  maxOutputTokens: number;
+  capabilities: ModelCapabilities;
+  knowledgeCutoff?: string;
+  default?: boolean;
+  deprecated?: boolean;
+};
+
+export type ProviderCatalogEntry = {
+  id: string;
+  name: string;
+  protocol: ProviderProtocol;
+  defaultBaseUrl: string;
+  auth: ProviderAuth;
+  apiKeyEnv?: string;
+  docsUrl?: string;
+  description?: string;
+  allowsCustomModels: boolean;
+  models: CatalogModel[];
+};
+
+export type ProviderCatalog = {
+  version: number;
+  providers: ProviderCatalogEntry[];
+};
+
+export const PROVIDER_CATALOG_QUERY_KEY = ["provider-catalog"] as const;
+
+export async function fetchProviderCatalog(): Promise<ProviderCatalog> {
+  return invoke<ProviderCatalog>("list_provider_catalog");
+}
+
+export function useProviderCatalog(enabled: boolean) {
+  return useQuery({
+    queryKey: PROVIDER_CATALOG_QUERY_KEY,
+    queryFn: fetchProviderCatalog,
+    enabled,
+    staleTime: Infinity,
+  });
+}
+
+export function findCatalogProvider(
+  catalog: ProviderCatalog | undefined,
+  providerId: string,
+): ProviderCatalogEntry | undefined {
+  return catalog?.providers.find((provider) => provider.id === providerId);
+}
+
+export function findCatalogModel(
+  provider: ProviderCatalogEntry | undefined,
+  modelId: string,
+): CatalogModel | undefined {
+  return provider?.models.find((model) => model.id === modelId);
+}
+
+export function getDefaultModel(
+  provider: ProviderCatalogEntry | undefined,
+): CatalogModel | undefined {
+  if (!provider) {
+    return undefined;
+  }
+
+  return provider.models.find((model) => model.default) ?? provider.models[0];
+}

--- a/src/shared/lib/providers/index.ts
+++ b/src/shared/lib/providers/index.ts
@@ -1,0 +1,16 @@
+export {
+  fetchProviderCatalog,
+  findCatalogModel,
+  findCatalogProvider,
+  getDefaultModel,
+  PROVIDER_CATALOG_QUERY_KEY,
+  useProviderCatalog,
+} from "./catalog";
+export type {
+  CatalogModel,
+  ModelCapabilities,
+  ProviderAuth,
+  ProviderCatalog,
+  ProviderCatalogEntry,
+  ProviderProtocol,
+} from "./catalog";


### PR DESCRIPTION
## Summary

Adds a built-in catalog of model providers and their models, parsed once on first access and exposed via a new `list_provider_catalog` Tauri command. This is foundational work for the multi-provider integration (opencode-style) — subsequent branches wire it into the settings UI, chat composer, and adapter layer.

## Scope

- [x] Feature

## Why now

Today the chat is hard-coded to a single OpenAI-compatible endpoint with four hand-rolled presets. Supporting several providers at once (Anthropic, Gemini, OpenRouter, Groq, …) first requires a single source of truth for provider metadata and model capabilities. Inline JSON keeps things deterministic, testable, and version-controlled.

## What changed

**Backend (Rust)**
- `src-tauri/src/features/providers/catalog.json` — 15 providers, ~80 models with `contextWindow`, `maxOutputTokens`, capability flags (`vision`, `toolCalls`, `reasoning`, `audio`), optional `knowledgeCutoff`, per-provider `default` marker.
- `src-tauri/src/features/providers/catalog.rs` — typed catalog with `ProviderProtocol` (openai|anthropic|gemini) and `ProviderAuth` (api_key|none) enums; embedded via `include_str!`, parsed once behind `OnceLock`. Six unit tests for parse, uniqueness, baseUrl shape, default count, model id uniqueness, and presence of key providers.
- `mod.rs`, `providers/commands.rs`, `app/commands.rs`, `app/bootstrap.rs` — register the `list_provider_catalog` Tauri command.

**Frontend (TypeScript)**
- `src/shared/lib/providers/catalog.ts` — TS types mirroring the Rust schema, `fetchProviderCatalog`, `useProviderCatalog` React Query hook (`staleTime: Infinity`), and helpers (`findCatalogProvider`, `findCatalogModel`, `getDefaultModel`). Placed in `shared/` per `ARCHITECTURE.md` so both `provider-settings` and the future chat picker can import without crossing feature boundaries.
- `src/shared/lib/__tests__/provider-catalog.test.ts` — four tests covering helpers and the `invoke` wrapper.

## Validation

- [x] `npm run check` (format, lint, typecheck, 15 tests including 4 new — all pass)
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib catalog` — 6/6

## Risks

- Catalog is shipped with the binary; refreshing models requires a release. Acceptable for iteration 1; a models.dev refresh path can land later.
- `list_provider_catalog` has no consumer in this PR — UI wiring lands in the `feat/providers-settings-ui` and `feat/chat-model-picker` branches per the agreed plan.

## Documentation

- [x] `[skip-changelog]` — no user-facing behavior change yet. The CHANGELOG entry will accompany the branch that switches chat onto real multi-provider routing.

## Before requesting review

- [x] Local checks pass