### PR TITLE
feat(providers): protocol adapters for OpenAI, Anthropic, and Gemini

### DIFF
--- a/src-tauri/src/features/providers/adapters.rs
+++ b/src-tauri/src/features/providers/adapters.rs
@@ -1,0 +1,461 @@
+use reqwest::{Client, StatusCode};
+use serde_json::{json, Value};
+
+use crate::features::providers::catalog::ProviderProtocol;
+use crate::features::providers::model::{ChatMessage, ChatRole};
+
+const ANTHROPIC_API_VERSION: &str = "2023-06-01";
+const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 4096;
+
+/// Request input shared by every adapter. We keep it deliberately small and
+/// protocol-agnostic; per-adapter request shape is built inside each module.
+#[derive(Clone, Debug)]
+pub struct ChatRequest {
+    pub base_url: String,
+    pub api_key: Option<String>,
+    pub model: String,
+    pub messages: Vec<ChatMessage>,
+    /// Hint used by adapters that require an explicit cap (e.g. Anthropic).
+    /// Falls back to [`DEFAULT_MAX_OUTPUT_TOKENS`] when not provided.
+    pub max_output_tokens: Option<u32>,
+}
+
+/// Send a non-streaming chat completion through the protocol-specific
+/// adapter and return the assistant text.
+pub async fn complete(
+    protocol: ProviderProtocol,
+    client: &Client,
+    request: ChatRequest,
+) -> Result<String, String> {
+    if request.messages.is_empty() {
+        return Err("at least one chat message is required".to_string());
+    }
+
+    match protocol {
+        ProviderProtocol::Openai => openai::send(client, request).await,
+        ProviderProtocol::Anthropic => anthropic::send(client, request).await,
+        ProviderProtocol::Gemini => gemini::send(client, request).await,
+    }
+}
+
+fn role_str(role: ChatRole) -> &'static str {
+    match role {
+        ChatRole::System => "system",
+        ChatRole::User => "user",
+        ChatRole::Assistant => "assistant",
+    }
+}
+
+// ---------- OpenAI-compatible ----------
+
+pub mod openai {
+    use super::*;
+
+    pub fn build_body(model: &str, messages: &[ChatMessage]) -> Value {
+        json!({
+            "model": model,
+            "messages": messages
+                .iter()
+                .map(|message| json!({
+                    "role": role_str(message.role),
+                    "content": message.content,
+                }))
+                .collect::<Vec<_>>(),
+            "stream": false,
+        })
+    }
+
+    pub fn parse_response(payload: &str) -> Result<String, String> {
+        let value: Value = serde_json::from_str(payload)
+            .map_err(|error| format!("failed to parse provider response: {error}"))?;
+
+        let text = value
+            .get("choices")
+            .and_then(Value::as_array)
+            .and_then(|choices| choices.first())
+            .and_then(|choice| choice.get("message"))
+            .and_then(|message| message.get("content"))
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|content| !content.is_empty())
+            .ok_or_else(|| "provider response did not include a message".to_string())?;
+
+        Ok(text.to_string())
+    }
+
+    pub async fn send(client: &Client, request: ChatRequest) -> Result<String, String> {
+        let endpoint = format!("{}/chat/completions", request.base_url);
+        let body = build_body(&request.model, &request.messages);
+
+        let mut builder = client.post(endpoint).json(&body);
+        if let Some(api_key) = request.api_key.as_deref().filter(|key| !key.is_empty()) {
+            builder = builder.bearer_auth(api_key);
+        }
+
+        let payload = dispatch_text(builder).await?;
+        parse_response(&payload)
+    }
+}
+
+// ---------- Anthropic Messages API ----------
+
+pub mod anthropic {
+    use super::*;
+
+    /// Returns (request body, optional combined system prompt). System
+    /// messages are concatenated and surfaced at the top level — Anthropic
+    /// does not accept "system" inside the `messages` array.
+    pub fn build_body(
+        model: &str,
+        messages: &[ChatMessage],
+        max_tokens: u32,
+    ) -> Result<Value, String> {
+        let mut system_parts: Vec<String> = Vec::new();
+        let mut chat_parts: Vec<Value> = Vec::new();
+
+        for message in messages {
+            match message.role {
+                ChatRole::System => system_parts.push(message.content.clone()),
+                ChatRole::User | ChatRole::Assistant => {
+                    chat_parts.push(json!({
+                        "role": role_str(message.role),
+                        "content": message.content,
+                    }));
+                }
+            }
+        }
+
+        if chat_parts.is_empty() {
+            return Err("anthropic requires at least one user/assistant message".to_string());
+        }
+
+        let mut body = json!({
+            "model": model,
+            "max_tokens": max_tokens,
+            "messages": chat_parts,
+        });
+
+        if !system_parts.is_empty() {
+            body["system"] = Value::String(system_parts.join("\n\n"));
+        }
+
+        Ok(body)
+    }
+
+    pub fn parse_response(payload: &str) -> Result<String, String> {
+        let value: Value = serde_json::from_str(payload)
+            .map_err(|error| format!("failed to parse provider response: {error}"))?;
+
+        let text = value
+            .get("content")
+            .and_then(Value::as_array)
+            .map(|blocks| {
+                blocks
+                    .iter()
+                    .filter_map(|block| {
+                        let block_type = block.get("type").and_then(Value::as_str).unwrap_or("");
+                        if block_type != "text" {
+                            return None;
+                        }
+                        block.get("text").and_then(Value::as_str)
+                    })
+                    .collect::<Vec<_>>()
+                    .join("")
+            })
+            .map(|joined| joined.trim().to_string())
+            .filter(|joined| !joined.is_empty())
+            .ok_or_else(|| "provider response did not include a message".to_string())?;
+
+        Ok(text)
+    }
+
+    pub async fn send(client: &Client, request: ChatRequest) -> Result<String, String> {
+        let api_key = request
+            .api_key
+            .as_deref()
+            .filter(|key| !key.is_empty())
+            .ok_or_else(|| "anthropic requires an API key".to_string())?;
+
+        let body = build_body(
+            &request.model,
+            &request.messages,
+            request
+                .max_output_tokens
+                .unwrap_or(DEFAULT_MAX_OUTPUT_TOKENS),
+        )?;
+        let endpoint = format!("{}/messages", request.base_url);
+        let builder = client
+            .post(endpoint)
+            .header("x-api-key", api_key)
+            .header("anthropic-version", ANTHROPIC_API_VERSION)
+            .json(&body);
+
+        let payload = dispatch_text(builder).await?;
+        parse_response(&payload)
+    }
+}
+
+// ---------- Google Gemini Generative Language API ----------
+
+pub mod gemini {
+    use super::*;
+
+    /// Returns the request body. System messages are concatenated into a
+    /// top-level `systemInstruction`; user → "user", assistant → "model".
+    pub fn build_body(messages: &[ChatMessage]) -> Result<Value, String> {
+        let mut system_parts: Vec<String> = Vec::new();
+        let mut contents: Vec<Value> = Vec::new();
+
+        for message in messages {
+            match message.role {
+                ChatRole::System => system_parts.push(message.content.clone()),
+                ChatRole::User => contents.push(json!({
+                    "role": "user",
+                    "parts": [ { "text": message.content } ],
+                })),
+                ChatRole::Assistant => contents.push(json!({
+                    "role": "model",
+                    "parts": [ { "text": message.content } ],
+                })),
+            }
+        }
+
+        if contents.is_empty() {
+            return Err("gemini requires at least one user/assistant message".to_string());
+        }
+
+        let mut body = json!({ "contents": contents });
+        if !system_parts.is_empty() {
+            body["systemInstruction"] = json!({
+                "parts": [ { "text": system_parts.join("\n\n") } ],
+            });
+        }
+
+        Ok(body)
+    }
+
+    pub fn parse_response(payload: &str) -> Result<String, String> {
+        let value: Value = serde_json::from_str(payload)
+            .map_err(|error| format!("failed to parse provider response: {error}"))?;
+
+        let text = value
+            .get("candidates")
+            .and_then(Value::as_array)
+            .and_then(|candidates| candidates.first())
+            .and_then(|candidate| candidate.get("content"))
+            .and_then(|content| content.get("parts"))
+            .and_then(Value::as_array)
+            .map(|parts| {
+                parts
+                    .iter()
+                    .filter_map(|part| part.get("text").and_then(Value::as_str))
+                    .collect::<Vec<_>>()
+                    .join("")
+            })
+            .map(|joined| joined.trim().to_string())
+            .filter(|joined| !joined.is_empty())
+            .ok_or_else(|| "provider response did not include a message".to_string())?;
+
+        Ok(text)
+    }
+
+    pub async fn send(client: &Client, request: ChatRequest) -> Result<String, String> {
+        let api_key = request
+            .api_key
+            .as_deref()
+            .filter(|key| !key.is_empty())
+            .ok_or_else(|| "gemini requires an API key".to_string())?;
+
+        let body = build_body(&request.messages)?;
+        let endpoint = format!(
+            "{}/models/{}:generateContent",
+            request.base_url, request.model
+        );
+        let builder = client.post(endpoint).query(&[("key", api_key)]).json(&body);
+
+        let payload = dispatch_text(builder).await?;
+        parse_response(&payload)
+    }
+}
+
+// ---------- Shared HTTP plumbing ----------
+
+async fn dispatch_text(builder: reqwest::RequestBuilder) -> Result<String, String> {
+    let response = builder
+        .send()
+        .await
+        .map_err(|error| format!("failed to send provider request: {error}"))?;
+    let status = response.status();
+    let content = response
+        .text()
+        .await
+        .map_err(|error| format!("failed to read provider response: {error}"))?;
+
+    if status != StatusCode::OK {
+        return Err(format!("provider returned {status}: {content}"));
+    }
+
+    Ok(content)
+}
+
+// ---------- Unit tests (request shape + response parsing) ----------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg(role: ChatRole, content: &str) -> ChatMessage {
+        ChatMessage {
+            role,
+            content: content.to_string(),
+        }
+    }
+
+    // ----- OpenAI -----
+
+    #[test]
+    fn openai_body_serializes_history_in_order() {
+        let messages = vec![
+            msg(ChatRole::System, "be terse"),
+            msg(ChatRole::User, "hi"),
+            msg(ChatRole::Assistant, "hello"),
+            msg(ChatRole::User, "next"),
+        ];
+        let body = openai::build_body("gpt-4o-mini", &messages);
+        assert_eq!(body["model"], "gpt-4o-mini");
+        assert_eq!(body["stream"], false);
+        let arr = body["messages"].as_array().unwrap();
+        assert_eq!(arr.len(), 4);
+        assert_eq!(arr[0]["role"], "system");
+        assert_eq!(arr[0]["content"], "be terse");
+        assert_eq!(arr[1]["role"], "user");
+        assert_eq!(arr[2]["role"], "assistant");
+        assert_eq!(arr[3]["role"], "user");
+        assert_eq!(arr[3]["content"], "next");
+    }
+
+    #[test]
+    fn openai_parses_first_choice_message() {
+        let payload = r#"{"choices":[{"message":{"role":"assistant","content":"  result  "}}]}"#;
+        assert_eq!(openai::parse_response(payload).unwrap(), "result");
+    }
+
+    #[test]
+    fn openai_rejects_missing_message() {
+        let payload = r#"{"choices":[]}"#;
+        assert!(openai::parse_response(payload).is_err());
+    }
+
+    // ----- Anthropic -----
+
+    #[test]
+    fn anthropic_body_extracts_system_prompt() {
+        let messages = vec![
+            msg(ChatRole::System, "be terse"),
+            msg(ChatRole::System, "and accurate"),
+            msg(ChatRole::User, "hi"),
+            msg(ChatRole::Assistant, "hello"),
+            msg(ChatRole::User, "more"),
+        ];
+        let body =
+            anthropic::build_body("claude-opus-4-7", &messages, DEFAULT_MAX_OUTPUT_TOKENS).unwrap();
+        assert_eq!(body["model"], "claude-opus-4-7");
+        assert_eq!(body["max_tokens"], DEFAULT_MAX_OUTPUT_TOKENS);
+        assert_eq!(body["system"], "be terse\n\nand accurate");
+        let arr = body["messages"].as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0]["role"], "user");
+        assert_eq!(arr[1]["role"], "assistant");
+        assert_eq!(arr[2]["role"], "user");
+        assert!(body
+            .get("messages")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|message| message.get("role").and_then(Value::as_str) != Some("system")));
+    }
+
+    #[test]
+    fn anthropic_body_omits_system_when_absent() {
+        let messages = vec![msg(ChatRole::User, "hi")];
+        let body = anthropic::build_body("claude-sonnet-4-6", &messages, 1024).unwrap();
+        assert!(body.get("system").is_none());
+        assert_eq!(body["max_tokens"], 1024);
+    }
+
+    #[test]
+    fn anthropic_body_rejects_empty_conversation() {
+        let messages = vec![msg(ChatRole::System, "only system")];
+        let error = anthropic::build_body("claude-opus-4-7", &messages, 1024).unwrap_err();
+        assert!(error.contains("user/assistant"));
+    }
+
+    #[test]
+    fn anthropic_parses_text_blocks() {
+        let payload = r#"{
+            "content": [
+                {"type":"text","text":"first "},
+                {"type":"tool_use","id":"x","name":"y","input":{}},
+                {"type":"text","text":"second"}
+            ]
+        }"#;
+        assert_eq!(anthropic::parse_response(payload).unwrap(), "first second");
+    }
+
+    #[test]
+    fn anthropic_rejects_empty_content() {
+        let payload = r#"{"content":[]}"#;
+        assert!(anthropic::parse_response(payload).is_err());
+    }
+
+    // ----- Gemini -----
+
+    #[test]
+    fn gemini_body_maps_roles_and_extracts_system_instruction() {
+        let messages = vec![
+            msg(ChatRole::System, "be terse"),
+            msg(ChatRole::User, "hi"),
+            msg(ChatRole::Assistant, "hello"),
+            msg(ChatRole::User, "next"),
+        ];
+        let body = gemini::build_body(&messages).unwrap();
+        assert_eq!(body["systemInstruction"]["parts"][0]["text"], "be terse");
+        let contents = body["contents"].as_array().unwrap();
+        assert_eq!(contents.len(), 3);
+        assert_eq!(contents[0]["role"], "user");
+        assert_eq!(contents[0]["parts"][0]["text"], "hi");
+        assert_eq!(contents[1]["role"], "model");
+        assert_eq!(contents[1]["parts"][0]["text"], "hello");
+        assert_eq!(contents[2]["role"], "user");
+        assert_eq!(contents[2]["parts"][0]["text"], "next");
+    }
+
+    #[test]
+    fn gemini_body_rejects_empty_conversation() {
+        let messages = vec![msg(ChatRole::System, "only system")];
+        let error = gemini::build_body(&messages).unwrap_err();
+        assert!(error.contains("user/assistant"));
+    }
+
+    #[test]
+    fn gemini_parses_first_candidate_parts() {
+        let payload = r#"{
+            "candidates": [{
+                "content": {
+                    "parts": [
+                        {"text":"hello "},
+                        {"text":"world"}
+                    ]
+                }
+            }]
+        }"#;
+        assert_eq!(gemini::parse_response(payload).unwrap(), "hello world");
+    }
+
+    #[test]
+    fn gemini_rejects_empty_candidates() {
+        let payload = r#"{"candidates":[]}"#;
+        assert!(gemini::parse_response(payload).is_err());
+    }
+}

--- a/src-tauri/src/features/providers/mod.rs
+++ b/src-tauri/src/features/providers/mod.rs
@@ -1,3 +1,4 @@
+pub mod adapters;
 pub mod catalog;
 pub mod commands;
 pub mod credentials;

--- a/src-tauri/src/features/providers/model.rs
+++ b/src-tauri/src/features/providers/model.rs
@@ -143,53 +143,57 @@ pub struct LegacyProviderConfigFile {
     pub active: Option<ProviderSettings>,
 }
 
-// ---------- Chat message wire types (unchanged in this branch) ----------
+// ---------- Chat wire types ----------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChatRole {
+    System,
+    User,
+    Assistant,
+}
+
+impl ChatRole {
+    pub fn parse(role: &str) -> Result<Self, String> {
+        match role.trim().to_ascii_lowercase().as_str() {
+            "system" => Ok(ChatRole::System),
+            "user" => Ok(ChatRole::User),
+            "assistant" => Ok(ChatRole::Assistant),
+            other => Err(format!(
+                "unsupported chat role '{other}' (expected system|user|assistant)"
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ChatMessage {
+    pub role: ChatRole,
+    pub content: String,
+}
+
+/// Wire-level message coming from the UI. We keep it as plain strings for
+/// flexibility and convert to the typed [`ChatMessage`] internally.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WireChatMessage {
+    pub role: String,
+    pub content: String,
+}
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChatMessageInput {
-    pub text: String,
+    /// Convenience field for single-shot messages. Kept for backward
+    /// compatibility with the existing chat UI; new callers should send
+    /// `messages` instead. When both are present, `messages` wins.
+    #[serde(default)]
+    pub text: Option<String>,
+    #[serde(default)]
+    pub messages: Option<Vec<WireChatMessage>>,
 }
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChatMessageResponse {
     pub text: String,
-}
-
-#[derive(Deserialize, Serialize)]
-pub struct OpenAiChatMessage {
-    pub role: String,
-    pub content: String,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OpenAiChatRequest {
-    pub model: String,
-    pub messages: Vec<OpenAiChatMessage>,
-    pub stream: bool,
-}
-
-impl OpenAiChatRequest {
-    pub fn user_message(model: String, text: String) -> Self {
-        Self {
-            model,
-            messages: vec![OpenAiChatMessage {
-                role: "user".to_string(),
-                content: text,
-            }],
-            stream: false,
-        }
-    }
-}
-
-#[derive(Deserialize)]
-pub struct OpenAiChatResponse {
-    pub choices: Vec<OpenAiChatChoice>,
-}
-
-#[derive(Deserialize)]
-pub struct OpenAiChatChoice {
-    pub message: OpenAiChatMessage,
 }

--- a/src-tauri/src/features/providers/service.rs
+++ b/src-tauri/src/features/providers/service.rs
@@ -1,16 +1,15 @@
 use std::{collections::HashMap, fs, io, path::PathBuf};
 
-use reqwest::StatusCode;
 use tauri::{AppHandle, Manager};
 
-use crate::features::providers::catalog::{self, ProviderCatalogEntry, ProviderProtocol};
+use crate::features::providers::adapters::{self, ChatRequest};
+use crate::features::providers::catalog::{self, ProviderCatalogEntry};
 use crate::features::providers::credentials;
 use crate::features::providers::model::{
-    ActiveProviderView, ActiveSelection, ActiveSelectionInput, ChatMessageInput,
-    ChatMessageResponse, LegacyProviderConfigFile, NewProviderConnectionInput, OpenAiChatRequest,
-    OpenAiChatResponse, ProviderConfigFile, ProviderConnection, ProviderConnectionView,
-    ProviderSettingsInput, ProviderSettingsView, UpdateProviderConnectionInput,
-    PROVIDER_CONFIG_VERSION,
+    ActiveProviderView, ActiveSelection, ActiveSelectionInput, ChatMessage, ChatMessageInput,
+    ChatMessageResponse, ChatRole, LegacyProviderConfigFile, NewProviderConnectionInput,
+    ProviderConfigFile, ProviderConnection, ProviderConnectionView, ProviderSettingsInput,
+    ProviderSettingsView, UpdateProviderConnectionInput, WireChatMessage, PROVIDER_CONFIG_VERSION,
 };
 
 const PROVIDERS_CONFIG_FILE: &str = "providers.json";
@@ -703,61 +702,73 @@ pub fn remove_provider_credentials(
 
 // ---------- Chat ----------
 
+pub fn messages_from_input(input: &ChatMessageInput) -> Result<Vec<ChatMessage>, String> {
+    if let Some(messages) = &input.messages {
+        if messages.is_empty() {
+            return Err("messages must contain at least one entry".to_string());
+        }
+
+        let parsed: Result<Vec<ChatMessage>, String> =
+            messages.iter().map(parse_wire_message).collect();
+        return parsed;
+    }
+
+    let text = input
+        .text
+        .as_deref()
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .ok_or_else(|| "message is required".to_string())?;
+
+    Ok(vec![ChatMessage {
+        role: ChatRole::User,
+        content: text.to_string(),
+    }])
+}
+
+fn parse_wire_message(message: &WireChatMessage) -> Result<ChatMessage, String> {
+    let content = message.content.trim().to_string();
+    if content.is_empty() {
+        return Err("chat message content cannot be empty".to_string());
+    }
+    Ok(ChatMessage {
+        role: ChatRole::parse(&message.role)?,
+        content,
+    })
+}
+
+fn lookup_max_output_tokens(provider_id: &str, model: &str) -> Option<u32> {
+    catalog::catalog()
+        .providers
+        .iter()
+        .find(|provider| provider.id == provider_id)?
+        .models
+        .iter()
+        .find(|catalog_model| catalog_model.id == model)
+        .map(|catalog_model| catalog_model.max_output_tokens)
+}
+
 pub async fn send_chat_message(
     app: &AppHandle,
     input: ChatMessageInput,
 ) -> Result<ChatMessageResponse, String> {
-    let message = input.text.trim().to_string();
-    if message.is_empty() {
-        return Err("message is required".to_string());
-    }
-
+    let messages = messages_from_input(&input)?;
     let resolved = resolve_active_provider(app)?;
+    let entry = catalog_entry(&resolved.connection.provider_id)?;
 
-    // This branch keeps the legacy OpenAI-compatible call path. Routing by
-    // protocol lands in the adapters branch (#3) of the multi-provider plan.
-    if !matches!(
-        catalog_entry(&resolved.connection.provider_id)?.protocol,
-        ProviderProtocol::Openai
-    ) {
-        return Err(format!(
-            "provider '{}' is not yet supported in chat — multi-protocol adapters arrive in a follow-up update",
-            resolved.connection.provider_id
-        ));
-    }
-
-    let request = OpenAiChatRequest::user_message(resolved.model.clone(), message);
-    let endpoint = format!("{}/chat/completions", resolved.connection.base_url);
+    let request = ChatRequest {
+        base_url: resolved.connection.base_url.clone(),
+        api_key: resolved.api_key.clone(),
+        model: resolved.model.clone(),
+        messages,
+        max_output_tokens: lookup_max_output_tokens(
+            &resolved.connection.provider_id,
+            &resolved.model,
+        ),
+    };
 
     let client = reqwest::Client::new();
-    let mut builder = client.post(endpoint).json(&request);
-    if let Some(api_key) = resolved.api_key {
-        builder = builder.bearer_auth(api_key);
-    }
-
-    let response = builder
-        .send()
-        .await
-        .map_err(|error| format!("failed to send provider request: {error}"))?;
-    let status = response.status();
-    let content = response
-        .text()
-        .await
-        .map_err(|error| format!("failed to read provider response: {error}"))?;
-
-    if status != StatusCode::OK {
-        return Err(format!("provider returned {status}: {content}"));
-    }
-
-    let response: OpenAiChatResponse = serde_json::from_str(&content)
-        .map_err(|error| format!("failed to parse provider response: {error}"))?;
-    let text = response
-        .choices
-        .first()
-        .map(|choice| choice.message.content.trim().to_string())
-        .filter(|content| !content.is_empty())
-        .ok_or_else(|| "provider response did not include a message".to_string())?;
-
+    let text = adapters::complete(entry.protocol, &client, request).await?;
     Ok(ChatMessageResponse { text })
 }
 
@@ -911,5 +922,93 @@ mod tests {
         assert_eq!(validated.base_url, "https://api.openai.com/v1");
         assert_eq!(validated.default_model, "gpt-4o-mini");
         assert_eq!(validated.custom_models, vec!["foo".to_string()]);
+    }
+
+    // ---------- Chat input conversion ----------
+
+    #[test]
+    fn chat_role_parses_known_roles_case_insensitively() {
+        assert_eq!(ChatRole::parse("system").unwrap(), ChatRole::System);
+        assert_eq!(ChatRole::parse("USER").unwrap(), ChatRole::User);
+        assert_eq!(ChatRole::parse(" Assistant ").unwrap(), ChatRole::Assistant);
+    }
+
+    #[test]
+    fn chat_role_rejects_unknown_roles() {
+        let error = ChatRole::parse("tool").unwrap_err();
+        assert!(error.contains("unsupported chat role"));
+    }
+
+    #[test]
+    fn messages_from_input_wraps_legacy_text_as_single_user_message() {
+        let input = ChatMessageInput {
+            text: Some("  hello  ".to_string()),
+            messages: None,
+        };
+        let messages = messages_from_input(&input).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, ChatRole::User);
+        assert_eq!(messages[0].content, "hello");
+    }
+
+    #[test]
+    fn messages_from_input_prefers_explicit_history() {
+        let input = ChatMessageInput {
+            text: Some("ignored".to_string()),
+            messages: Some(vec![
+                WireChatMessage {
+                    role: "system".to_string(),
+                    content: " be terse ".to_string(),
+                },
+                WireChatMessage {
+                    role: "user".to_string(),
+                    content: "hi".to_string(),
+                },
+            ]),
+        };
+        let messages = messages_from_input(&input).unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, ChatRole::System);
+        assert_eq!(messages[0].content, "be terse");
+        assert_eq!(messages[1].role, ChatRole::User);
+        assert_eq!(messages[1].content, "hi");
+    }
+
+    #[test]
+    fn messages_from_input_rejects_empty_input() {
+        let input = ChatMessageInput {
+            text: Some("   ".to_string()),
+            messages: None,
+        };
+        assert!(messages_from_input(&input).is_err());
+    }
+
+    #[test]
+    fn messages_from_input_rejects_empty_messages_array() {
+        let input = ChatMessageInput {
+            text: None,
+            messages: Some(vec![]),
+        };
+        assert!(messages_from_input(&input).is_err());
+    }
+
+    #[test]
+    fn messages_from_input_rejects_blank_message_content() {
+        let input = ChatMessageInput {
+            text: None,
+            messages: Some(vec![WireChatMessage {
+                role: "user".to_string(),
+                content: "   ".to_string(),
+            }]),
+        };
+        assert!(messages_from_input(&input).is_err());
+    }
+
+    #[test]
+    fn lookup_max_output_tokens_matches_catalog_value() {
+        let tokens = lookup_max_output_tokens("openai", "gpt-4o-mini");
+        assert_eq!(tokens, Some(16384));
+        assert!(lookup_max_output_tokens("openai", "does-not-exist").is_none());
+        assert!(lookup_max_output_tokens("nope", "gpt-4o-mini").is_none());
     }
 }


### PR DESCRIPTION
## Summary

Replaces the hard-coded OpenAI-only chat call with a small adapter layer dispatching by the catalog protocol of the active provider's connection. Each adapter owns its request shape, auth scheme, and response parsing. The chat command now accepts a messages history alongside the legacy `text` field so follow-up branches can wire full conversation history without another wire change.

## Scope

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Infrastructure / CI
- [ ] Documentation

## Why now

Step 3 of the opencode-style multi-provider integration. The catalog (PR #39) and multi-connection storage (PR #40) are in; chat is still bolted to OpenAI's `/chat/completions`. This branch makes Anthropic and Gemini connections actually answer when they're active, without touching the UI yet.

## What changed

**New: `src-tauri/src/features/providers/adapters.rs`**

A protocol-agnostic `ChatRequest { base_url, api_key, model, messages, max_output_tokens }` is dispatched through `complete(protocol, client, request)` to one of three implementations:

- **OpenAI** — `POST {base}/chat/completions`, `Authorization: Bearer <key>`, body `{ model, messages, stream: false }`. Parses `choices[0].message.content`.
- **Anthropic** — `POST {base}/messages` with `x-api-key` and `anthropic-version: 2023-06-01`. Body `{ model, max_tokens, system?, messages }`. System messages are concatenated and surfaced at the top level because the Messages API rejects `role: "system"` inside `messages[]`. `max_tokens` is pulled from the catalog model entry (falls back to 4096).
- **Gemini** — `POST {base}/models/{model}:generateContent?key=<key>`. Body `{ contents, systemInstruction? }` with `user → "user"` and `assistant → "model"` role mapping. Non-text response parts (e.g. function calls) are skipped during parsing rather than erroring.

Each module exposes `build_body` / `parse_response` separately from `send` so the bodies and parsers can be exercised without HTTP.

**`src-tauri/src/features/providers/model.rs`**

- Added `ChatRole` enum + `ChatRole::parse` (case-insensitive, errors on unknown).
- Added `ChatMessage` (typed) and `WireChatMessage` (wire shape from the UI).
- `ChatMessageInput` now accepts either `text: Option<String>` (legacy single-turn) or `messages: Option<Vec<WireChatMessage>>` (preferred). If both are present, `messages` wins.
- Removed the now-unused `OpenAi*` request/response types (their behavior lives inside `adapters::openai`).

**`src-tauri/src/features/providers/service.rs`**

- New `messages_from_input` converts the wire input to `Vec<ChatMessage>`, rejecting empty / blank inputs.
- New `lookup_max_output_tokens(provider_id, model)` looks the value up in the catalog so the Anthropic adapter gets a model-appropriate cap.
- `send_chat_message` is now a thin wrapper: resolve active provider → look up protocol from catalog → build `ChatRequest` → dispatch through `adapters::complete`. The temporary `"not yet supported"` error string is gone.

**`src-tauri/src/features/providers/mod.rs`** — `pub mod adapters`.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` — 38/38 (20 new)
- [x] `npm run check` — 15/15

**New tests** (20):
- `features::providers::adapters::tests` (12) — OpenAI body order + response parse + missing-message error, Anthropic system extraction + `system` omission when absent + only-system rejection + multi-block text parse + empty content error, Gemini role mapping + system instruction + only-system rejection + part concatenation + empty candidates error.
- `features::providers::service::tests` (8 new) — `ChatRole::parse` case-insensitive happy path + unknown rejection, `messages_from_input` four code paths (text wraps to single user message, explicit `messages` preferred over `text`, blank text rejected, empty `messages` rejected, blank content rejected), `lookup_max_output_tokens` hit + two miss cases.

Manual verification is intentionally not part of this PR — the chat composer still sends a single text and is rewritten in the upcoming `feat/chat-real-providers` branch.

## Risks

- **Anthropic strict alternation.** The Messages API requires user/assistant alternation; this adapter does not validate that. If the UI sends a malformed history the provider returns 400 and we surface the body verbatim. Easy to add a validator in a follow-up if needed.
- **Gemini key on URL.** Per the Generative Language API, the API key goes in `?key=...`. The call is made from Rust, so the URL is not exposed to the webview / devtools / frontend logs and the key never leaves the keyring.
- **No streaming.** This branch is non-streaming; streaming arrives in `feat/providers-streaming` after the picker lands.
- **No UI changes.** The active provider must already be an Anthropic/Gemini connection for the new code paths to run — and those connections can't be created from the UI until `feat/providers-settings-ui`.

## Documentation

- [ ] Docs updated
- [ ] `CHANGELOG.md` updated for user-facing changes
- [x] Internal-only change: `[skip-changelog]` — backend-only addition with no user-visible behavior change yet (no UI surface creates non-OpenAI connections). The changelog entry will accompany the branch that flips the chat onto real multi-provider routing.
- [ ] Docs not needed (explain in Summary)

## Before requesting review

- [x] Local checks pass
- [ ] CI is green