### PR TITLE
feat(chat): wire chat shell to the configured provider

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ This file defines module boundaries and dependency direction.
 - `src/app/main.tsx` - bootstrap and root providers.
 - `src/app/App.tsx` - shell layout and feature composition.
 - `src/app/model` - global overlay/window state and shell hooks.
-- `src/features/chat-shell` - chat-like mock conversation surface and composer.
+- `src/features/chat-shell` - chat surface and composer, talks to the active provider via Tauri commands.
 - `src/features/overlay-header` - header controls (settings + close) and drag zone.
 - `src/features/settings-modal` - temporary settings modal shell.
 - `src/features/provider-settings` - provider credential/configuration UI for chat requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Write entries from user impact first, then technical detail.
 
 ### Added
 
-- Chat-first overlay shell scaffold with a mock message composer (`Message` input + `Send`) and temporary local mock response flow.
+- Chat-first overlay shell with a `Message` input + `Send` composer wired to the configured provider.
 - Header controls with `Settings` trigger and a temporary empty Settings modal.
 
 - Global overlay hotkey support with default `Ctrl+Shift+Space` to hide/show the main overlay window.
@@ -24,6 +24,7 @@ Write entries from user impact first, then technical detail.
 
 ### Changed
 
+- Chat now talks to the configured provider for real: the mock welcome message and "Mock response" placeholder are gone, the header reads "Chat", and the composer maintains and sends the full conversation history. When the desktop runtime is unavailable, no provider is connected, or the active provider has no API key, the composer is disabled and an in-place CTA points to Settings → Providers.
 - Main overlay UI now uses a chat-oriented layout with a draggable header region and focus on conversational input flow.
 - Settings modal is now rebuilt with shadcn dialog/tabs primitives and structured into category navigation (`MCP servers`, `Hotkeys`, `Skills`, `Providers`) with a dedicated content area.
 - Desktop capability permissions now explicitly allow header drag-start and app close actions.

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -3,8 +3,12 @@ import { expect, test } from "@playwright/test";
 test("app shell renders", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page.getByRole("heading", { name: "AI chat mock" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Chat" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
   await expect(page.getByRole("textbox", { name: "Message" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Send" })).toBeDisabled();
+  await expect(
+    page.getByText("Open the desktop runtime to chat with a configured provider."),
+  ).toBeVisible();
 });

--- a/src/app/model/__tests__/overlay-ui.integration.test.tsx
+++ b/src/app/model/__tests__/overlay-ui.integration.test.tsx
@@ -18,8 +18,13 @@ describe("App", () => {
     const user = userEvent.setup();
     renderApp();
 
-    expect(screen.getByRole("heading", { name: /ai chat mock/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /^chat$/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /send/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /send/i })).toBeDisabled();
+    expect(screen.getByRole("textbox", { name: /message/i })).toBeDisabled();
+    expect(
+      screen.getByText(/open the desktop runtime to chat with a configured provider/i),
+    ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /settings/i }));
     expect(screen.getByRole("dialog", { name: /settings/i })).toBeInTheDocument();
@@ -39,11 +44,5 @@ describe("App", () => {
 
     await user.click(screen.getByRole("button", { name: /^close$/i }));
     expect(screen.queryByRole("dialog", { name: /settings/i })).not.toBeInTheDocument();
-
-    await user.type(screen.getByRole("textbox", { name: /message/i }), "hello");
-    await user.click(screen.getByRole("button", { name: /send/i }));
-
-    expect(screen.getByText("hello")).toBeInTheDocument();
-    expect(screen.getByText(/mock response:/i)).toBeInTheDocument();
   });
 });

--- a/src/features/chat-shell/model/__tests__/use-chat-shell.test.tsx
+++ b/src/features/chat-shell/model/__tests__/use-chat-shell.test.tsx
@@ -1,0 +1,184 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChatShell } from "@/features/chat-shell/model/use-chat-shell";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+
+const invokeMock = vi.mocked(invoke);
+
+function wrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function freshClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+}
+
+beforeEach(() => {
+  invokeMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useChatShell", () => {
+  it("starts in browser availability when not in Tauri runtime", () => {
+    const { result } = renderHook(() => useChatShell(false), {
+      wrapper: wrapper(freshClient()),
+    });
+
+    expect(result.current.availability.status).toBe("browser");
+    expect(result.current.messages).toHaveLength(0);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("reports no-provider when get_active_provider resolves to null", async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "get_active_provider") {
+        return null;
+      }
+      throw new Error(`unexpected command ${command}`);
+    });
+
+    const { result } = renderHook(() => useChatShell(true), {
+      wrapper: wrapper(freshClient()),
+    });
+
+    await waitFor(() => {
+      expect(result.current.availability.status).toBe("no-provider");
+    });
+  });
+
+  it("reports no-api-key when active provider has no key saved", async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "get_active_provider") {
+        return {
+          connectionId: "openai",
+          providerId: "openai",
+          protocol: "openai",
+          baseUrl: "https://api.openai.com/v1",
+          model: "gpt-4o-mini",
+          hasApiKey: false,
+        };
+      }
+      throw new Error(`unexpected command ${command}`);
+    });
+
+    const { result } = renderHook(() => useChatShell(true), {
+      wrapper: wrapper(freshClient()),
+    });
+
+    await waitFor(() => {
+      expect(result.current.availability.status).toBe("no-api-key");
+    });
+  });
+
+  it("submitDraft is a no-op while availability is not ready", async () => {
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command === "get_active_provider") {
+        return null;
+      }
+      throw new Error(`unexpected command ${command}`);
+    });
+
+    const { result } = renderHook(() => useChatShell(true), {
+      wrapper: wrapper(freshClient()),
+    });
+
+    await waitFor(() => {
+      expect(result.current.availability.status).toBe("no-provider");
+    });
+
+    act(() => {
+      result.current.setDraft("hi");
+    });
+    await act(async () => {
+      await result.current.submitDraft();
+    });
+
+    expect(result.current.messages).toHaveLength(0);
+    expect(invokeMock).not.toHaveBeenCalledWith("send_chat_message", expect.anything());
+  });
+
+  it("sends the full conversation history when ready and appends the reply", async () => {
+    invokeMock.mockImplementation(async (command: string, args?: unknown) => {
+      if (command === "get_active_provider") {
+        return {
+          connectionId: "openai",
+          providerId: "openai",
+          protocol: "openai",
+          baseUrl: "https://api.openai.com/v1",
+          model: "gpt-4o-mini",
+          hasApiKey: true,
+        };
+      }
+      if (command === "send_chat_message") {
+        const messages =
+          (args as { input?: { messages?: { role: string; content: string }[] } } | undefined)
+            ?.input?.messages ?? [];
+        // Echo the last user message for assertion convenience.
+        const lastUser = [...messages].reverse().find((message) => message.role === "user");
+        return { text: `echo: ${lastUser?.content ?? ""}` };
+      }
+      throw new Error(`unexpected command ${command}`);
+    });
+
+    const { result } = renderHook(() => useChatShell(true), {
+      wrapper: wrapper(freshClient()),
+    });
+
+    await waitFor(() => {
+      expect(result.current.availability.status).toBe("ready");
+    });
+
+    act(() => {
+      result.current.setDraft("hello");
+    });
+    await act(async () => {
+      await result.current.submitDraft();
+    });
+
+    expect(result.current.messages.map((message) => message.text)).toEqual([
+      "hello",
+      "echo: hello",
+    ]);
+
+    act(() => {
+      result.current.setDraft("second");
+    });
+    await act(async () => {
+      await result.current.submitDraft();
+    });
+
+    expect(result.current.messages.map((message) => message.text)).toEqual([
+      "hello",
+      "echo: hello",
+      "second",
+      "echo: second",
+    ]);
+
+    const sendCalls = invokeMock.mock.calls.filter(([command]) => command === "send_chat_message");
+    expect(sendCalls).toHaveLength(2);
+    const secondCallInput = sendCalls[1][1] as {
+      input: { messages: { role: string; content: string }[] };
+    };
+    expect(secondCallInput.input.messages).toEqual([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "echo: hello" },
+      { role: "user", content: "second" },
+    ]);
+  });
+});

--- a/src/features/chat-shell/model/api.ts
+++ b/src/features/chat-shell/model/api.ts
@@ -1,9 +1,18 @@
 import { invoke } from "@tauri-apps/api/core";
 
+export type ChatRole = "system" | "user" | "assistant";
+
+export type WireChatMessage = {
+  role: ChatRole;
+  content: string;
+};
+
 export type ChatMessageResponse = {
   text: string;
 };
 
-export async function sendChatMessage(text: string): Promise<ChatMessageResponse> {
-  return invoke<ChatMessageResponse>("send_chat_message", { input: { text } });
+export async function sendChatMessage(messages: WireChatMessage[]): Promise<ChatMessageResponse> {
+  return invoke<ChatMessageResponse>("send_chat_message", {
+    input: { messages },
+  });
 }

--- a/src/features/chat-shell/model/use-chat-shell.ts
+++ b/src/features/chat-shell/model/use-chat-shell.ts
@@ -1,30 +1,71 @@
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { toErrorMessage } from "@/shared/lib/to-error-message";
-import { sendChatMessage } from "./api";
+import { useActiveProvider, type ActiveProviderView } from "@/shared/lib/providers";
+import { sendChatMessage, type WireChatMessage } from "./api";
 
-type ChatMessage = {
+export type ChatMessage = {
   id: string;
   role: "assistant" | "user";
   text: string;
 };
 
-const INITIAL_MESSAGES: ChatMessage[] = [
-  {
-    id: "assistant-welcome",
-    role: "assistant",
-    text: "Mock chat is ready. Type any text and press Send.",
-  },
-];
+export type ChatAvailability =
+  | { status: "browser" }
+  | { status: "loading" }
+  | { status: "no-provider" }
+  | { status: "no-api-key"; provider: ActiveProviderView }
+  | { status: "ready"; provider: ActiveProviderView };
 
-export function useChatShell(tauriRuntime: boolean) {
+export type UseChatShellResult = {
+  availability: ChatAvailability;
+  draft: string;
+  isSending: boolean;
+  messages: ChatMessage[];
+  sendError: string;
+  sendStatus: string;
+  setDraft: (value: string) => void;
+  submitDraft: () => Promise<void>;
+};
+
+function deriveAvailability(
+  tauriRuntime: boolean,
+  isLoading: boolean,
+  provider: ActiveProviderView | null | undefined,
+): ChatAvailability {
+  if (!tauriRuntime) {
+    return { status: "browser" };
+  }
+  if (isLoading) {
+    return { status: "loading" };
+  }
+  if (!provider) {
+    return { status: "no-provider" };
+  }
+  if (!provider.hasApiKey) {
+    return { status: "no-api-key", provider };
+  }
+  return { status: "ready", provider };
+}
+
+export function useChatShell(tauriRuntime: boolean): UseChatShellResult {
   const [draft, setDraft] = useState("");
-  const [messages, setMessages] = useState<ChatMessage[]>(INITIAL_MESSAGES);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [sendStatus, setSendStatus] = useState("");
   const [sendError, setSendError] = useState("");
   const [isSending, setIsSending] = useState(false);
   const sequenceRef = useRef(0);
 
+  const activeProviderQuery = useActiveProvider(tauriRuntime);
+  const availability = useMemo(
+    () => deriveAvailability(tauriRuntime, activeProviderQuery.isLoading, activeProviderQuery.data),
+    [tauriRuntime, activeProviderQuery.isLoading, activeProviderQuery.data],
+  );
+
   async function submitDraft() {
+    if (availability.status !== "ready") {
+      return;
+    }
+
     const nextDraft = draft.trim();
 
     if (!nextDraft) {
@@ -41,30 +82,24 @@ export function useChatShell(tauriRuntime: boolean) {
       text: nextDraft,
     };
 
-    setMessages((prev) => [...prev, userMessage]);
+    const history: WireChatMessage[] = [
+      ...messages.map((message) => ({
+        role: message.role,
+        content: message.text,
+      })),
+      { role: "user", content: nextDraft },
+    ];
+
+    setMessages((previous) => [...previous, userMessage]);
     setDraft("");
     setSendStatus("");
     setSendError("");
-
-    if (!tauriRuntime) {
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: `assistant-${idPrefix}`,
-          role: "assistant",
-          text: "Mock response: open the desktop runtime to use a configured provider.",
-        },
-      ]);
-      setSendStatus("Message sent in mock mode.");
-      return;
-    }
-
     setIsSending(true);
 
     try {
-      const response = await sendChatMessage(nextDraft);
-      setMessages((prev) => [
-        ...prev,
+      const response = await sendChatMessage(history);
+      setMessages((previous) => [
+        ...previous,
         {
           id: `assistant-${idPrefix}`,
           role: "assistant",
@@ -80,6 +115,7 @@ export function useChatShell(tauriRuntime: boolean) {
   }
 
   return {
+    availability,
     draft,
     isSending,
     messages,

--- a/src/features/chat-shell/ui/chat-shell.tsx
+++ b/src/features/chat-shell/ui/chat-shell.tsx
@@ -1,3 +1,4 @@
+import type { ChatAvailability } from "@/features/chat-shell/model/use-chat-shell";
 import { useChatShell } from "@/features/chat-shell/model/use-chat-shell";
 import { Button } from "@/shared/ui/button";
 
@@ -5,34 +6,72 @@ type Props = {
   tauriRuntime: boolean;
 };
 
+function availabilityCopy(availability: ChatAvailability): string | null {
+  switch (availability.status) {
+    case "browser":
+      return "Open the desktop runtime to chat with a configured provider.";
+    case "loading":
+      return "Loading active provider...";
+    case "no-provider":
+      return "Connect a provider in Settings → Providers to start chatting.";
+    case "no-api-key":
+      return `Add an API key for ${availability.provider.providerId} in Settings → Providers.`;
+    case "ready":
+      return null;
+  }
+}
+
+function subtitle(availability: ChatAvailability): string {
+  if (availability.status === "ready" || availability.status === "no-api-key") {
+    return `${availability.provider.providerId} · ${availability.provider.model}`;
+  }
+  return "No provider connected";
+}
+
 export function ChatShell({ tauriRuntime }: Props) {
-  const { draft, isSending, messages, sendError, sendStatus, setDraft, submitDraft } =
+  const { availability, draft, isSending, messages, sendError, sendStatus, setDraft, submitDraft } =
     useChatShell(tauriRuntime);
+
+  const cta = availabilityCopy(availability);
+  const composerDisabled = availability.status !== "ready" || isSending;
+  const sendDisabled = composerDisabled || draft.trim().length === 0;
 
   return (
     <section className="flex flex-1 flex-col gap-3">
       <div>
         <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Overlay Chat</p>
-        <h1 className="text-2xl font-semibold tracking-tight">AI chat mock</h1>
+        <div className="flex items-baseline justify-between gap-2">
+          <h1 className="text-2xl font-semibold tracking-tight">Chat</h1>
+          <span className="text-xs text-muted-foreground">{subtitle(availability)}</span>
+        </div>
       </div>
 
-      <ul className="flex max-h-72 min-h-56 flex-col gap-3 overflow-y-auto rounded-xl border border-border/70 bg-muted/30 p-3">
-        {messages.map((message) => (
-          <li
-            key={message.id}
-            className={message.role === "user" ? "flex justify-end" : "flex justify-start"}
-          >
-            <p
-              className={
-                message.role === "user"
-                  ? "max-w-[80%] rounded-2xl rounded-br-sm bg-primary px-3 py-2 text-sm text-primary-foreground"
-                  : "max-w-[80%] rounded-2xl rounded-bl-sm border border-border/80 bg-card px-3 py-2 text-sm"
-              }
-            >
-              {message.text}
-            </p>
+      <ul
+        aria-label="Conversation"
+        className="flex max-h-72 min-h-56 flex-col gap-3 overflow-y-auto rounded-xl border border-border/70 bg-muted/30 p-3"
+      >
+        {messages.length === 0 ? (
+          <li className="m-auto max-w-[80%] text-center text-sm text-muted-foreground">
+            {cta ?? "Send a message to start the conversation."}
           </li>
-        ))}
+        ) : (
+          messages.map((message) => (
+            <li
+              key={message.id}
+              className={message.role === "user" ? "flex justify-end" : "flex justify-start"}
+            >
+              <p
+                className={
+                  message.role === "user"
+                    ? "max-w-[80%] rounded-2xl rounded-br-sm bg-primary px-3 py-2 text-sm text-primary-foreground"
+                    : "max-w-[80%] rounded-2xl rounded-bl-sm border border-border/80 bg-card px-3 py-2 text-sm"
+                }
+              >
+                {message.text}
+              </p>
+            </li>
+          ))
+        )}
       </ul>
 
       <form
@@ -46,15 +85,16 @@ export function ChatShell({ tauriRuntime }: Props) {
           aria-label="Message"
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
-          placeholder="Type your message..."
-          disabled={isSending}
-          className="h-10 flex-1 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
+          placeholder={cta ?? "Type your message..."}
+          disabled={composerDisabled}
+          className="h-10 flex-1 rounded-md border border-input bg-background px-3 text-sm shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
         />
-        <Button type="submit" disabled={isSending}>
+        <Button type="submit" disabled={sendDisabled}>
           {isSending ? "Sending..." : "Send"}
         </Button>
       </form>
 
+      {messages.length > 0 && cta ? <p className="text-xs text-muted-foreground">{cta}</p> : null}
       {sendStatus ? <p className="text-xs text-muted-foreground">{sendStatus}</p> : null}
       {sendError ? <p className="text-xs text-destructive">{sendError}</p> : null}
     </section>

--- a/src/shared/lib/providers/active-provider.ts
+++ b/src/shared/lib/providers/active-provider.ts
@@ -1,0 +1,27 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useQuery } from "@tanstack/react-query";
+import type { ProviderProtocol } from "./catalog";
+
+export type ActiveProviderView = {
+  connectionId: string;
+  providerId: string;
+  protocol: ProviderProtocol;
+  baseUrl: string;
+  model: string;
+  hasApiKey: boolean;
+};
+
+export const ACTIVE_PROVIDER_QUERY_KEY = ["active-provider"] as const;
+
+export async function fetchActiveProvider(): Promise<ActiveProviderView | null> {
+  return invoke<ActiveProviderView | null>("get_active_provider");
+}
+
+export function useActiveProvider(enabled: boolean) {
+  return useQuery({
+    queryKey: ACTIVE_PROVIDER_QUERY_KEY,
+    queryFn: fetchActiveProvider,
+    enabled,
+    staleTime: 30_000,
+  });
+}

--- a/src/shared/lib/providers/index.ts
+++ b/src/shared/lib/providers/index.ts
@@ -1,4 +1,10 @@
 export {
+  ACTIVE_PROVIDER_QUERY_KEY,
+  fetchActiveProvider,
+  useActiveProvider,
+} from "./active-provider";
+export type { ActiveProviderView } from "./active-provider";
+export {
   fetchProviderCatalog,
   findCatalogModel,
   findCatalogProvider,


### PR DESCRIPTION
## Summary

Drops every chat mock and points the composer at the configured provider for real. The header is now "Chat", the welcome message and "Mock response" placeholder are gone, the composer keeps a real conversation history in component state and sends it as `messages[]` to the existing `send_chat_message` command. When chat isn't usable (browser preview, no active provider, or active provider without an API key) the composer disables itself and shows an in-place CTA pointing at Settings → Providers.

## Scope

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Infrastructure / CI
- [ ] Documentation

## Why now

Step 4 of the opencode-style multi-provider integration. With the catalog, multi-connection storage, and adapters in (#39, #40, #41), the backend can actually answer; the chat surface was still hard-coded to a mock. This PR is the first user-visible result of the previous backend work.

## What changed

**`src/shared/lib/providers/active-provider.ts`** (new) — React Query hook `useActiveProvider`, `fetchActiveProvider`, and the `ActiveProviderView` type, calling the `get_active_provider` Tauri command from PR #40. Placed in `shared/` per `ARCHITECTURE.md` so both the chat surface and the upcoming Settings rewrite share the same source of truth.

**`src/features/chat-shell/model/api.ts`** — `sendChatMessage` now takes `WireChatMessage[]` and posts it as `{ input: { messages } }`. The old single-string signature is gone.

**`src/features/chat-shell/model/use-chat-shell.ts`** — `INITIAL_MESSAGES` removed, `!tauriRuntime` mock branch removed. Adds a typed `ChatAvailability` union (`browser | loading | no-provider | no-api-key | ready`) derived from `useActiveProvider`. `submitDraft` is a no-op until availability is `"ready"`; on send it builds the full history `[...messages, new user]` and posts it.

**`src/features/chat-shell/ui/chat-shell.tsx`** — Header renamed to "Chat" with a subtitle showing `providerId · model` (or "No provider connected"). Empty conversation slot shows the CTA derived from availability; composer + send button disable for every non-ready state.

**Tests**

- New `src/features/chat-shell/model/__tests__/use-chat-shell.test.tsx` (5 tests):
  - Browser availability without firing any `invoke`.
  - `no-provider` when `get_active_provider` returns `null`.
  - `no-api-key` when the response has `hasApiKey: false`.
  - `submitDraft` is a no-op while not ready (no `send_chat_message` call).
  - The second send carries the full history `[user, assistant, user]` to the backend.
- Updated `src/app/model/__tests__/overlay-ui.integration.test.tsx`: asserts the new "Chat" heading, the disabled composer, and the desktop-runtime CTA in place of the old mock-response checks.

**Docs**
- `CHANGELOG.md` Unreleased / Changed entry covering the user-facing behavior.
- `ARCHITECTURE.md` description for `features/chat-shell` updated.

## Validation

- [x] `npm run check` — format, lint, typecheck, 20 tests (8 files, 5 new). All green.
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [ ] Manual verification — pending real provider once Settings rewrite (`feat/providers-settings-ui`) lands. The unit tests cover the wire shape end-to-end via the mocked `invoke`.

## Risks

- **No streaming yet.** The assistant reply still arrives as one block; streaming lands in `feat/providers-streaming` later in the plan.
- **History grows unbounded in memory.** A single conversation lives in component state and is sent in full on every turn. Trimming and persistence are out of scope for this branch — opencode does the same trick until the user starts a new conversation.
- **Failed sends keep the user message in the list.** Matches the prevailing UX pattern; we can revisit if it becomes confusing.
- **Settings UI is still single-provider** — the multi-connection management surface arrives in `feat/providers-settings-ui`. Until then "Connect a provider" effectively means using the existing single-active form.

## Documentation

- [x] Docs updated (`ARCHITECTURE.md`)
- [x] `CHANGELOG.md` updated for user-facing changes
- [ ] Internal-only change
- [ ] Docs not needed

## Before requesting review

- [x] Local checks pass
- [ ] CI is green