### PR TITLE
refactor(ui): implement Lumina Chat design system across overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>overlay-core</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Sora:wght@300;400;500;600;700&family=Fira+Code:wght@400;500&display=swap"
+    />
   </head>
 
   <body>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -16,10 +16,10 @@ export default function App() {
   useOverlayWindowSizeSync({ panelRef, tauriRuntime });
 
   return (
-    <main className="p-3 text-foreground opacity-75">
+    <main className="p-3 text-foreground">
       <section
         ref={panelRef}
-        className="relative mx-auto flex w-full max-w-3xl flex-col gap-4 overflow-hidden rounded-2xl border border-border/80 bg-card/95 p-4 shadow-2xl backdrop-blur"
+        className="lumina-overlay-glow relative mx-auto flex w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-[color:var(--input)] bg-card/85 shadow-2xl backdrop-blur"
       >
         <OverlayHeader tauriRuntime={tauriRuntime} onOpenSettings={openSettings} />
         <ChatShell tauriRuntime={tauriRuntime} />

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -5,13 +5,14 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
-  --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
-  --radius-2xl: calc(var(--radius) + 8px);
-  --radius-3xl: calc(var(--radius) + 12px);
-  --radius-4xl: calc(var(--radius) + 16px);
+  --radius-sm: var(--radius-sm-value);
+  --radius-md: var(--radius-md-value);
+  --radius-lg: var(--radius-lg-value);
+  --radius-xl: var(--radius-xl-value);
+  --radius-2xl: var(--radius-2xl-value);
+  --radius-3xl: 28px;
+  --radius-4xl: 32px;
+
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -43,75 +44,123 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+
+  --color-surface-1: var(--surface-1);
+  --color-surface-2: var(--surface-2);
+  --color-surface-3: var(--surface-3);
+  --color-text-muted: var(--text-muted-strong);
+  --color-indigo-50: var(--indigo-50);
+  --color-indigo-100: var(--indigo-100);
+  --color-indigo-200: var(--indigo-200);
+  --color-indigo-400: var(--indigo-400);
+  --color-indigo-500: var(--indigo-500);
+  --color-indigo-600: var(--indigo-600);
+  --color-indigo-700: var(--indigo-700);
+  --color-indigo-900: var(--indigo-900);
+  --color-amber-200: var(--amber-200);
+  --color-amber-400: var(--amber-400);
+  --color-amber-500: var(--amber-500);
+  --color-amber-600: var(--amber-600);
+  --color-teal-400: var(--teal-400);
+  --color-teal-500: var(--teal-500);
+  --color-rose-400: var(--rose-400);
+  --color-rose-500: var(--rose-500);
+  --color-green-400: var(--green-400);
+  --color-green-500: var(--green-500);
+
+  --font-sans: "Sora", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "Fira Code", ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  /* Lumina palette */
+  --background: #0c0e14;
+  --foreground: #eef0ff;
+
+  --surface-1: #131720;
+  --surface-2: #1a1f2e;
+  --surface-3: #222840;
+
+  --card: var(--surface-1);
+  --card-foreground: #eef0ff;
+  --popover: var(--surface-1);
+  --popover-foreground: #eef0ff;
+
+  --primary: #6366f1;
+  --primary-foreground: #ffffff;
+  --secondary: var(--surface-2);
+  --secondary-foreground: #eef0ff;
+  --muted: var(--surface-2);
+  --muted-foreground: #8b90b8;
+  --text-muted-strong: #4a5070;
+  --accent: var(--surface-3);
+  --accent-foreground: #eef0ff;
+  --destructive: #f43f5e;
+
+  --border: rgba(255, 255, 255, 0.07);
+  --input: rgba(255, 255, 255, 0.13);
+  --ring: #6366f1;
+
+  --indigo-50: #eeedff;
+  --indigo-100: #c9c6ff;
+  --indigo-200: #a09aff;
+  --indigo-400: #7c72ff;
+  --indigo-500: #6366f1;
+  --indigo-600: #4f46e5;
+  --indigo-700: #3730a3;
+  --indigo-900: #1e1b4b;
+  --amber-200: #fcd34d;
+  --amber-400: #fbbf24;
+  --amber-500: #f59e0b;
+  --amber-600: #d97706;
+  --teal-400: #2dd4bf;
+  --teal-500: #14b8a6;
+  --rose-400: #fb7185;
+  --rose-500: #f43f5e;
+  --green-400: #4ade80;
+  --green-500: #22c55e;
+
+  --radius-sm-value: 6px;
+  --radius-md-value: 10px;
+  --radius-lg-value: 14px;
+  --radius-xl-value: 20px;
+  --radius-2xl-value: 24px;
+
+  --chart-1: #6366f1;
+  --chart-2: #2dd4bf;
+  --chart-3: #f59e0b;
+  --chart-4: #fb7185;
+  --chart-5: #4ade80;
+  --sidebar: var(--surface-1);
+  --sidebar-foreground: #eef0ff;
+  --sidebar-primary: #6366f1;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: var(--surface-2);
+  --sidebar-accent-foreground: #eef0ff;
+  --sidebar-border: rgba(255, 255, 255, 0.07);
+  --sidebar-ring: #6366f1;
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  /* The overlay ships dark-only; expose the same tokens under .dark for safety. */
+  --background: #0c0e14;
+  --foreground: #eef0ff;
+  --card: var(--surface-1);
+  --card-foreground: #eef0ff;
+  --popover: var(--surface-1);
+  --popover-foreground: #eef0ff;
+  --primary: #6366f1;
+  --primary-foreground: #ffffff;
+  --secondary: var(--surface-2);
+  --secondary-foreground: #eef0ff;
+  --muted: var(--surface-2);
+  --muted-foreground: #8b90b8;
+  --accent: var(--surface-3);
+  --accent-foreground: #eef0ff;
+  --destructive: #f43f5e;
+  --border: rgba(255, 255, 255, 0.07);
+  --input: rgba(255, 255, 255, 0.13);
+  --ring: #6366f1;
 }
 
 html,
@@ -123,4 +172,74 @@ body,
 
 body {
   margin: 0;
+  font-family: var(--font-sans);
+  font-feature-settings: "ss01", "ss02", "cv11";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  color: var(--foreground);
+}
+
+/* Reusable Lumina components */
+
+.lumina-bubble-blink {
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+}
+
+.lumina-bubble-blink span {
+  width: 4px;
+  height: 4px;
+  background: var(--indigo-400);
+  border-radius: 9999px;
+  animation: lumina-blink 1.2s infinite;
+}
+
+.lumina-bubble-blink span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.lumina-bubble-blink span:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes lumina-blink {
+  0%,
+  80%,
+  100% {
+    opacity: 0.2;
+  }
+  40% {
+    opacity: 1;
+  }
+}
+
+.lumina-overlay-glow {
+  background:
+    radial-gradient(120% 80% at 0% 0%, rgba(99, 102, 241, 0.18) 0%, transparent 55%),
+    radial-gradient(120% 80% at 100% 100%, rgba(20, 184, 166, 0.1) 0%, transparent 55%),
+    linear-gradient(135deg, rgba(26, 16, 64, 0.85) 0%, rgba(10, 15, 30, 0.95) 100%);
+}
+
+.lumina-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: var(--surface-3) transparent;
+}
+
+.lumina-scrollbar::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.lumina-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.lumina-scrollbar::-webkit-scrollbar-thumb {
+  background-color: var(--surface-3);
+  border-radius: 9999px;
+}
+
+.lumina-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: var(--indigo-400);
 }

--- a/src/features/chat-shell/ui/chat-shell.tsx
+++ b/src/features/chat-shell/ui/chat-shell.tsx
@@ -1,6 +1,7 @@
 import type { ChatAvailability } from "@/features/chat-shell/model/use-chat-shell";
 import { useChatShell } from "@/features/chat-shell/model/use-chat-shell";
-import { Button } from "@/shared/ui/button";
+import { Badge } from "@/shared/ui/badge";
+import { cn } from "@/shared/lib/utils";
 
 type Props = {
   tauriRuntime: boolean;
@@ -21,11 +22,63 @@ function availabilityCopy(availability: ChatAvailability): string | null {
   }
 }
 
-function subtitle(availability: ChatAvailability): string {
-  if (availability.status === "ready" || availability.status === "no-api-key") {
-    return `${availability.provider.providerId} · ${availability.provider.model}`;
+function StatusIndicator({ availability }: { availability: ChatAvailability }) {
+  switch (availability.status) {
+    case "ready":
+      return (
+        <Badge tone="green" withDot>
+          Online
+        </Badge>
+      );
+    case "loading":
+      return (
+        <Badge tone="amber" withDot>
+          Loading
+        </Badge>
+      );
+    case "no-api-key":
+      return (
+        <Badge tone="amber" withDot>
+          API key required
+        </Badge>
+      );
+    case "no-provider":
+      return (
+        <Badge tone="rose" withDot>
+          No provider
+        </Badge>
+      );
+    case "browser":
+      return (
+        <Badge tone="neutral" withDot>
+          Browser preview
+        </Badge>
+      );
   }
-  return "No provider connected";
+}
+
+function providerModel(availability: ChatAvailability): string | null {
+  if (availability.status === "ready" || availability.status === "no-api-key") {
+    return availability.provider.model;
+  }
+  return null;
+}
+
+function SendIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <path d="M12 20V4M5 11l7-7 7 7" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function UserGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden>
+      <circle cx="12" cy="8" r="3.5" />
+      <path d="M5 20c1.5-3.5 4.2-5 7-5s5.5 1.5 7 5" strokeLinecap="round" />
+    </svg>
+  );
 }
 
 export function ChatShell({ tauriRuntime }: Props) {
@@ -35,43 +88,85 @@ export function ChatShell({ tauriRuntime }: Props) {
   const cta = availabilityCopy(availability);
   const composerDisabled = availability.status !== "ready" || isSending;
   const sendDisabled = composerDisabled || draft.trim().length === 0;
+  const model = providerModel(availability);
 
   return (
-    <section className="flex flex-1 flex-col gap-3">
-      <div>
-        <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Overlay Chat</p>
-        <div className="flex items-baseline justify-between gap-2">
-          <h1 className="text-2xl font-semibold tracking-tight">Chat</h1>
-          <span className="text-xs text-muted-foreground">{subtitle(availability)}</span>
+    <section className="flex flex-1 flex-col gap-4 px-4 py-4">
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted-strong)]">
+            Overlay Chat
+          </p>
+          <h1 className="mt-1 text-lg font-semibold leading-tight tracking-tight">Chat</h1>
+        </div>
+        <div className="flex flex-col items-end gap-1.5">
+          <StatusIndicator availability={availability} />
+          {model ? (
+            <span className="font-mono text-[10px] text-muted-foreground">{model}</span>
+          ) : null}
         </div>
       </div>
 
       <ul
         aria-label="Conversation"
-        className="flex max-h-72 min-h-56 flex-col gap-3 overflow-y-auto rounded-xl border border-border/70 bg-muted/30 p-3"
+        className="lumina-scrollbar flex max-h-72 min-h-56 flex-col gap-3 overflow-y-auto rounded-xl border border-border bg-surface-1 p-3"
       >
         {messages.length === 0 ? (
-          <li className="m-auto max-w-[80%] text-center text-sm text-muted-foreground">
+          <li className="m-auto max-w-[80%] text-center text-xs leading-relaxed text-muted-foreground">
             {cta ?? "Send a message to start the conversation."}
           </li>
         ) : (
-          messages.map((message) => (
-            <li
-              key={message.id}
-              className={message.role === "user" ? "flex justify-end" : "flex justify-start"}
-            >
-              <p
-                className={
-                  message.role === "user"
-                    ? "max-w-[80%] rounded-2xl rounded-br-sm bg-primary px-3 py-2 text-sm text-primary-foreground"
-                    : "max-w-[80%] rounded-2xl rounded-bl-sm border border-border/80 bg-card px-3 py-2 text-sm"
-                }
+          messages.map((message) => {
+            const isUser = message.role === "user";
+            return (
+              <li
+                key={message.id}
+                className={cn("flex items-start gap-2", isUser ? "flex-row-reverse" : "flex-row")}
               >
-                {message.text}
-              </p>
-            </li>
-          ))
+                <span
+                  className={cn(
+                    "mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-sm border text-[10px] font-semibold",
+                    isUser
+                      ? "border-[color:var(--input)] bg-surface-3 text-muted-foreground"
+                      : "border-indigo-500/30 bg-indigo-900/60 text-indigo-200",
+                  )}
+                  aria-hidden
+                >
+                  {isUser ? <UserGlyph /> : "AI"}
+                </span>
+                <p
+                  className={cn(
+                    "max-w-[78%] px-3 py-2 text-xs leading-relaxed",
+                    isUser
+                      ? "rounded-md rounded-br-[4px] bg-indigo-600 text-white"
+                      : "rounded-md rounded-bl-[4px] border border-border bg-surface-2 text-foreground",
+                  )}
+                >
+                  {message.text}
+                </p>
+              </li>
+            );
+          })
         )}
+
+        {isSending ? (
+          <li className="flex items-start gap-2">
+            <span
+              aria-hidden
+              className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-sm border border-indigo-500/30 bg-indigo-900/60 text-[10px] font-semibold text-indigo-200"
+            >
+              AI
+            </span>
+            <span className="inline-flex items-center gap-2 rounded-md border border-border bg-surface-2 px-3 py-2 text-[11px] italic text-muted-foreground">
+              <span className="lumina-bubble-blink" aria-hidden>
+                <span />
+                <span />
+                <span />
+              </span>
+              Thinking...
+            </span>
+          </li>
+        ) : null}
       </ul>
 
       <form
@@ -79,24 +174,44 @@ export function ChatShell({ tauriRuntime }: Props) {
           event.preventDefault();
           void submitDraft();
         }}
-        className="flex items-center gap-2"
+        className="flex items-end gap-2 rounded-xl border border-[color:var(--input)] bg-surface-2 px-3 py-2 focus-within:border-indigo-500/40"
       >
-        <input
+        <textarea
           aria-label="Message"
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              if (!sendDisabled) {
+                void submitDraft();
+              }
+            }
+          }}
           placeholder={cta ?? "Type your message..."}
           disabled={composerDisabled}
-          className="h-10 flex-1 rounded-md border border-input bg-background px-3 text-sm shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
+          rows={1}
+          className="lumina-scrollbar max-h-32 flex-1 resize-none bg-transparent text-xs text-foreground placeholder:text-[color:var(--text-muted-strong)] focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
         />
-        <Button type="submit" disabled={sendDisabled}>
-          {isSending ? "Sending..." : "Send"}
-        </Button>
+        <button
+          type="submit"
+          disabled={sendDisabled}
+          aria-label="Send"
+          title="Send"
+          className="flex size-8 shrink-0 items-center justify-center rounded-md bg-primary text-white shadow-sm transition-colors hover:bg-indigo-600 disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:size-4"
+        >
+          <SendIcon />
+          <span className="sr-only">{isSending ? "Sending..." : "Send"}</span>
+        </button>
       </form>
 
-      {messages.length > 0 && cta ? <p className="text-xs text-muted-foreground">{cta}</p> : null}
-      {sendStatus ? <p className="text-xs text-muted-foreground">{sendStatus}</p> : null}
-      {sendError ? <p className="text-xs text-destructive">{sendError}</p> : null}
+      {(messages.length > 0 && cta) || sendStatus || sendError ? (
+        <div className="flex flex-col gap-1 text-[11px]">
+          {messages.length > 0 && cta ? <p className="text-muted-foreground">{cta}</p> : null}
+          {sendStatus ? <p className="text-muted-foreground">{sendStatus}</p> : null}
+          {sendError ? <p className="text-rose-400">{sendError}</p> : null}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/src/features/hotkey-settings/ui/hotkey-settings-panel.tsx
+++ b/src/features/hotkey-settings/ui/hotkey-settings-panel.tsx
@@ -74,34 +74,50 @@ export function HotkeySettingsPanel({ tauriRuntime }: Props) {
   }
 
   return (
-    <section className="rounded-lg border bg-muted/40 p-4 text-sm">
-      <p className="font-medium">Hotkeys</p>
-      <p className="mt-1 text-muted-foreground">{hotkeySupportHint}</p>
+    <section className="flex flex-col gap-4">
+      <header>
+        <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted-strong)]">
+          Hotkeys
+        </p>
+        <h2 className="mt-1 text-base font-semibold text-foreground">Keyboard shortcuts</h2>
+        <p className="mt-1 max-w-prose text-xs leading-relaxed text-muted-foreground">
+          {hotkeySupportHint}
+        </p>
+      </header>
 
-      <div className="mt-4 space-y-3">
+      <ul className="flex flex-col gap-2">
         {hotkeyRows.map((hotkeyRow) => {
           const isCapturing = capturingAction === hotkeyRow.action;
           const currentValue = hotkeyRow.accelerator || "Not set";
           const canClear = !controlsDisabled && Boolean(hotkeyRow.accelerator);
 
           return (
-            <div
+            <li
               key={hotkeyRow.action}
-              className="grid gap-3 rounded-lg border border-border/70 bg-background/80 p-3 md:grid-cols-[1fr_auto] md:items-center"
+              className="grid gap-3 rounded-lg border border-border bg-surface-1 p-3 md:grid-cols-[1fr_auto] md:items-center"
             >
               <div>
-                <p className="text-sm font-medium">{hotkeyRow.title}</p>
-                <p className="mt-1 text-xs text-muted-foreground">{hotkeyRow.description}</p>
+                <p className="text-sm font-medium text-foreground">{hotkeyRow.title}</p>
+                <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+                  {hotkeyRow.description}
+                </p>
               </div>
 
-              <div className="flex flex-wrap items-center justify-start gap-2 md:justify-end">
-                <span className="rounded-md border border-border/70 bg-muted/20 px-3 py-1.5 font-mono text-xs">
+              <div className="flex flex-wrap items-center justify-start gap-1.5 md:justify-end">
+                <span
+                  className={
+                    "rounded-sm border px-2.5 py-1 font-mono text-[11px] " +
+                    (isCapturing
+                      ? "border-indigo-500/40 bg-indigo-500/10 text-indigo-200"
+                      : "border-[color:var(--input)] bg-surface-2 text-foreground/85")
+                  }
+                >
                   {isCapturing ? "Press shortcut..." : currentValue}
                 </span>
                 <Button
                   type="button"
                   size="sm"
-                  variant={isCapturing ? "secondary" : "outline"}
+                  variant={isCapturing ? "primary" : "secondary"}
                   onClick={() => handleCaptureToggle(hotkeyRow.action)}
                   disabled={controlsDisabled}
                 >
@@ -117,20 +133,22 @@ export function HotkeySettingsPanel({ tauriRuntime }: Props) {
                   Clear
                 </Button>
               </div>
-            </div>
+            </li>
           );
         })}
-      </div>
+      </ul>
 
-      {capturingAction ? (
-        <p className="mt-3 text-xs text-muted-foreground">
-          Press a shortcut now. Press Escape to cancel capture.
-        </p>
-      ) : null}
-      {captureError ? <p className="mt-2 text-xs text-destructive">{captureError}</p> : null}
-      {savingAction ? <p className="mt-2 text-xs text-muted-foreground">Saving hotkey...</p> : null}
-      {hotkeyStatus ? <p className="mt-3 text-xs text-muted-foreground">{hotkeyStatus}</p> : null}
-      {hotkeyError ? <p className="mt-2 text-xs text-destructive">{hotkeyError}</p> : null}
+      <div className="flex flex-col gap-1 text-[11px]">
+        {capturingAction ? (
+          <p className="text-muted-foreground">
+            Press a shortcut now. Press Escape to cancel capture.
+          </p>
+        ) : null}
+        {captureError ? <p className="text-rose-400">{captureError}</p> : null}
+        {savingAction ? <p className="text-muted-foreground">Saving hotkey...</p> : null}
+        {hotkeyStatus ? <p className="text-muted-foreground">{hotkeyStatus}</p> : null}
+        {hotkeyError ? <p className="text-rose-400">{hotkeyError}</p> : null}
+      </div>
     </section>
   );
 }

--- a/src/features/overlay-header/ui/overlay-header.tsx
+++ b/src/features/overlay-header/ui/overlay-header.tsx
@@ -1,4 +1,5 @@
 import { useOverlayWindowControls } from "@/features/overlay-header/model/use-overlay-window-controls";
+import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 
 type Props = {
@@ -6,32 +7,84 @@ type Props = {
   onOpenSettings: () => void;
 };
 
+function LogoMark() {
+  return (
+    <span
+      aria-hidden
+      className="flex size-8 items-center justify-center rounded-md bg-primary text-white shadow-sm"
+    >
+      <svg viewBox="0 0 18 18" className="size-4 fill-current">
+        <path d="M9 2L3 6v6l6 4 6-4V6L9 2zm0 2.2L13.5 7v4.5L9 14l-4.5-2.5V7L9 4.2z" opacity="0.5" />
+        <circle cx="9" cy="9" r="2.5" />
+      </svg>
+    </span>
+  );
+}
+
+function GearIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.87l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.7 1.7 0 0 0-1.87-.34 1.7 1.7 0 0 0-1.03 1.56V21a2 2 0 1 1-4 0v-.09a1.7 1.7 0 0 0-1.11-1.56 1.7 1.7 0 0 0-1.87.34l-.06.06A2 2 0 1 1 4.13 16.92l.06-.06a1.7 1.7 0 0 0 .34-1.87 1.7 1.7 0 0 0-1.56-1.03H3a2 2 0 1 1 0-4h.09A1.7 1.7 0 0 0 4.65 8.85a1.7 1.7 0 0 0-.34-1.87l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.7 1.7 0 0 0 1.87.34H9a1.7 1.7 0 0 0 1.03-1.56V3a2 2 0 1 1 4 0v.09a1.7 1.7 0 0 0 1.03 1.56 1.7 1.7 0 0 0 1.87-.34l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.7 1.7 0 0 0-.34 1.87V9a1.7 1.7 0 0 0 1.56 1.03H21a2 2 0 1 1 0 4h-.09a1.7 1.7 0 0 0-1.51 1z" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden>
+      <path d="M6 6l12 12M18 6L6 18" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 export function OverlayHeader({ tauriRuntime, onOpenSettings }: Props) {
   const { closeOverlay, isClosePending } = useOverlayWindowControls(tauriRuntime);
 
   return (
-    <header className="space-y-2">
-      <div className="flex items-center gap-2">
-        <div
-          data-tauri-drag-region=""
-          aria-hidden
-          className="h-8 flex-1 rounded-md border border-dashed border-border/70 bg-muted/30"
-        />
-
-        <Button type="button" variant="outline" size="sm" onClick={onOpenSettings}>
-          Settings
-        </Button>
-
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => void closeOverlay()}
-          disabled={!tauriRuntime || isClosePending}
-        >
-          {isClosePending ? "Closing..." : "Close app"}
-        </Button>
+    <header className="flex items-center gap-3 border-b border-border px-4 py-3">
+      <LogoMark />
+      <div
+        data-tauri-drag-region=""
+        className="flex flex-1 cursor-grab select-none flex-col gap-0.5 active:cursor-grabbing"
+      >
+        <div className="flex items-baseline gap-2">
+          <span className="text-sm font-semibold text-foreground">
+            Lumina <span className="text-indigo-400">Chat</span>
+          </span>
+          <Badge
+            tone="indigo"
+            className="font-mono text-[10px]"
+            style={{ paddingTop: 2, paddingBottom: 2 }}
+          >
+            v1.0
+          </Badge>
+        </div>
+        <span className="text-[11px] text-muted-foreground">AI overlay assistant</span>
       </div>
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        onClick={onOpenSettings}
+        aria-label="Settings"
+        title="Settings"
+      >
+        <GearIcon />
+      </Button>
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        onClick={() => void closeOverlay()}
+        disabled={!tauriRuntime || isClosePending}
+        aria-label={isClosePending ? "Closing..." : "Close app"}
+        title={isClosePending ? "Closing..." : "Close app"}
+      >
+        <CloseIcon />
+      </Button>
     </header>
   );
 }

--- a/src/features/provider-settings/ui/connection-editor.tsx
+++ b/src/features/provider-settings/ui/connection-editor.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { findCatalogProvider, type ProviderCatalog } from "@/shared/lib/providers";
+import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import { toErrorMessage } from "@/shared/lib/to-error-message";
 import type { ProviderConnectionView } from "@/features/provider-settings/model/api";
@@ -22,6 +23,11 @@ type Props = {
   onDone: (connection: ProviderConnectionView) => void;
   onCancel: () => void;
 };
+
+const fieldLabelClass =
+  "text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--text-muted-strong)]";
+const inputClass =
+  "h-9 rounded-md border border-[color:var(--input)] bg-surface-1 px-3 text-xs text-foreground placeholder:text-[color:var(--text-muted-strong)] outline-none transition-colors focus:border-indigo-500/50 disabled:cursor-not-allowed disabled:opacity-60";
 
 function defaultInitialState(
   mode: ConnectionFormMode,
@@ -127,168 +133,181 @@ export function ConnectionEditor({ mode, catalog, initialConnection, onDone, onC
 
   return (
     <form
-      className="grid gap-4"
+      className="flex flex-col gap-4"
       onSubmit={(event) => {
         event.preventDefault();
         void submit();
       }}
     >
-      <header className="flex items-baseline justify-between gap-2">
-        <h3 className="text-sm font-medium">
-          {mode === "add" ? "Add provider connection" : `Edit ${initialConnection?.displayName}`}
-        </h3>
-        <span className="text-xs text-muted-foreground">
-          {provider?.protocol ? `Protocol: ${provider.protocol}` : null}
-        </span>
+      <header className="flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted-strong)]">
+            {mode === "add" ? "New connection" : "Edit connection"}
+          </p>
+          <h3 className="mt-1 text-base font-semibold text-foreground">
+            {mode === "add" ? "Add provider connection" : initialConnection?.displayName}
+          </h3>
+        </div>
+        {provider?.protocol ? (
+          <Badge tone="indigo" className="font-mono">
+            {provider.protocol}
+          </Badge>
+        ) : null}
       </header>
 
-      <label className="grid gap-1.5">
-        <span className="text-xs font-medium text-muted-foreground">Provider</span>
-        <select
-          value={state.providerId}
-          onChange={(event) => applyProvider(event.target.value)}
-          disabled={mode === "edit" || isSubmitting}
-          className="h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm disabled:opacity-60"
-        >
-          {catalog.providers.map((entry) => (
-            <option key={entry.id} value={entry.id}>
-              {entry.name}
-            </option>
-          ))}
-        </select>
-        {provider?.description ? (
-          <span className="text-xs text-muted-foreground">{provider.description}</span>
-        ) : null}
-      </label>
-
-      <label className="grid gap-1.5">
-        <span className="text-xs font-medium text-muted-foreground">Display name</span>
-        <input
-          value={state.displayName}
-          onChange={(event) => patch({ displayName: event.target.value })}
-          disabled={isSubmitting}
-          className="h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
-        />
-      </label>
-
-      <label className="grid gap-1.5">
-        <span className="flex items-center justify-between text-xs font-medium text-muted-foreground">
-          <span>Base URL</span>
-          {provider && state.baseUrl !== provider.defaultBaseUrl ? (
-            <button
-              type="button"
-              onClick={resetBaseUrl}
-              disabled={isSubmitting}
-              className="text-xs font-normal text-foreground/70 underline-offset-2 hover:underline"
-            >
-              Reset to default
-            </button>
-          ) : null}
-        </span>
-        <input
-          value={state.baseUrl}
-          onChange={(event) => patch({ baseUrl: event.target.value })}
-          disabled={isSubmitting}
-          placeholder="https://api.example.com/v1"
-          className="h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
-        />
-      </label>
-
-      <label className="grid gap-1.5">
-        <span className="text-xs font-medium text-muted-foreground">Default model</span>
-        <input
-          list={`models-${state.providerId}`}
-          value={state.defaultModel}
-          onChange={(event) => patch({ defaultModel: event.target.value })}
-          disabled={isSubmitting}
-          placeholder="model-id"
-          className="h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
-        />
-        <datalist id={`models-${state.providerId}`}>
-          {options.map((model) => (
-            <option key={model} value={model} />
-          ))}
-        </datalist>
-      </label>
-
-      <fieldset className="grid gap-2 rounded-md border border-border/70 p-3">
-        <legend className="px-1 text-xs font-medium text-muted-foreground">Custom models</legend>
-        {state.customModels.length === 0 ? (
-          <p className="text-xs text-muted-foreground">
-            Catalog models are always available. Add user-supplied model ids if your endpoint
-            exposes models not in the catalog.
-          </p>
-        ) : (
-          <ul className="flex flex-wrap gap-2">
-            {state.customModels.map((model) => (
-              <li
-                key={model}
-                className="flex items-center gap-1 rounded-full border border-border/70 bg-background px-2 py-0.5 text-xs"
-              >
-                <span>{model}</span>
-                <button
-                  type="button"
-                  onClick={() => setState((current) => removeCustomModel(current, model))}
-                  disabled={isSubmitting}
-                  aria-label={`Remove ${model}`}
-                  className="text-muted-foreground hover:text-destructive"
-                >
-                  ×
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-
-        <div className="flex items-center gap-2">
-          <input
-            value={state.customModelDraft}
-            onChange={(event) => patch({ customModelDraft: event.target.value })}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") {
-                event.preventDefault();
-                setState((current) => addCustomModel(current));
-              }
-            }}
-            disabled={isSubmitting}
-            placeholder="add-model-id"
-            className="h-9 flex-1 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
-          />
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            onClick={() => setState((current) => addCustomModel(current))}
-            disabled={isSubmitting || state.customModelDraft.trim().length === 0}
+      <div className="grid gap-4">
+        <label className="grid gap-1.5">
+          <span className={fieldLabelClass}>Provider</span>
+          <select
+            value={state.providerId}
+            onChange={(event) => applyProvider(event.target.value)}
+            disabled={mode === "edit" || isSubmitting}
+            className={inputClass}
           >
-            Add
-          </Button>
-        </div>
-      </fieldset>
+            {catalog.providers.map((entry) => (
+              <option key={entry.id} value={entry.id}>
+                {entry.name}
+              </option>
+            ))}
+          </select>
+          {provider?.description ? (
+            <span className="text-[11px] text-muted-foreground">{provider.description}</span>
+          ) : null}
+        </label>
 
-      <label className="grid gap-1.5">
-        <span className="text-xs font-medium text-muted-foreground">
-          API key {apiKeyRequired ? null : "(not required)"}
-        </span>
-        <input
-          type="password"
-          value={state.apiKey}
-          onChange={(event) => patch({ apiKey: event.target.value })}
-          disabled={isSubmitting}
-          placeholder={
-            initialConnection?.hasApiKey ? "Leave blank to keep the saved key" : "Provider token"
-          }
-          className="h-10 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
-        />
-      </label>
+        <label className="grid gap-1.5">
+          <span className={fieldLabelClass}>Display name</span>
+          <input
+            value={state.displayName}
+            onChange={(event) => patch({ displayName: event.target.value })}
+            disabled={isSubmitting}
+            className={inputClass}
+          />
+        </label>
 
-      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+        <label className="grid gap-1.5">
+          <span className={`flex items-center justify-between ${fieldLabelClass}`}>
+            <span>Base URL</span>
+            {provider && state.baseUrl !== provider.defaultBaseUrl ? (
+              <button
+                type="button"
+                onClick={resetBaseUrl}
+                disabled={isSubmitting}
+                className="text-[10px] font-normal normal-case tracking-normal text-indigo-200 underline-offset-2 hover:underline"
+              >
+                Reset to default
+              </button>
+            ) : null}
+          </span>
+          <input
+            value={state.baseUrl}
+            onChange={(event) => patch({ baseUrl: event.target.value })}
+            disabled={isSubmitting}
+            placeholder="https://api.example.com/v1"
+            className={`${inputClass} font-mono`}
+          />
+        </label>
 
-      <footer className="flex justify-end gap-2">
+        <label className="grid gap-1.5">
+          <span className={fieldLabelClass}>Default model</span>
+          <input
+            list={`models-${state.providerId}`}
+            value={state.defaultModel}
+            onChange={(event) => patch({ defaultModel: event.target.value })}
+            disabled={isSubmitting}
+            placeholder="model-id"
+            className={`${inputClass} font-mono`}
+          />
+          <datalist id={`models-${state.providerId}`}>
+            {options.map((model) => (
+              <option key={model} value={model} />
+            ))}
+          </datalist>
+        </label>
+
+        <fieldset className="grid gap-2 rounded-md border border-border bg-surface-1 p-3">
+          <legend className={`${fieldLabelClass} px-1`}>Custom models</legend>
+          {state.customModels.length === 0 ? (
+            <p className="text-[11px] text-muted-foreground">
+              Catalog models are always available. Add user-supplied model ids if your endpoint
+              exposes models not in the catalog.
+            </p>
+          ) : (
+            <ul className="flex flex-wrap gap-1.5">
+              {state.customModels.map((model) => (
+                <li
+                  key={model}
+                  className="flex items-center gap-1 rounded-full border border-[color:var(--input)] bg-surface-2 px-2 py-0.5 font-mono text-[10px] text-foreground"
+                >
+                  <span>{model}</span>
+                  <button
+                    type="button"
+                    onClick={() => setState((current) => removeCustomModel(current, model))}
+                    disabled={isSubmitting}
+                    aria-label={`Remove ${model}`}
+                    className="ml-1 text-muted-foreground transition-colors hover:text-rose-400"
+                  >
+                    ×
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className="flex items-center gap-2">
+            <input
+              value={state.customModelDraft}
+              onChange={(event) => patch({ customModelDraft: event.target.value })}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  setState((current) => addCustomModel(current));
+                }
+              }}
+              disabled={isSubmitting}
+              placeholder="add-model-id"
+              className={`${inputClass} font-mono`}
+            />
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={() => setState((current) => addCustomModel(current))}
+              disabled={isSubmitting || state.customModelDraft.trim().length === 0}
+            >
+              Add
+            </Button>
+          </div>
+        </fieldset>
+
+        <label className="grid gap-1.5">
+          <span className={fieldLabelClass}>
+            API key {apiKeyRequired ? null : <span className="normal-case">(not required)</span>}
+          </span>
+          <input
+            type="password"
+            value={state.apiKey}
+            onChange={(event) => patch({ apiKey: event.target.value })}
+            disabled={isSubmitting}
+            placeholder={
+              initialConnection?.hasApiKey ? "Leave blank to keep the saved key" : "Provider token"
+            }
+            className={inputClass}
+          />
+        </label>
+      </div>
+
+      {error ? (
+        <p className="rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-[11px] text-rose-400">
+          {error}
+        </p>
+      ) : null}
+
+      <footer className="flex items-center justify-end gap-2 pt-1">
         <Button type="button" size="sm" variant="ghost" onClick={onCancel} disabled={isSubmitting}>
           Cancel
         </Button>
-        <Button type="submit" size="sm" disabled={isSubmitting}>
+        <Button type="submit" size="sm" variant="primary" disabled={isSubmitting}>
           {isSubmitting ? "Saving..." : mode === "add" ? "Add connection" : "Save changes"}
         </Button>
       </footer>

--- a/src/features/provider-settings/ui/provider-settings-panel.tsx
+++ b/src/features/provider-settings/ui/provider-settings-panel.tsx
@@ -4,8 +4,10 @@ import {
   useProviderCatalog,
   type ProviderCatalogEntry,
 } from "@/shared/lib/providers";
+import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import { toErrorMessage } from "@/shared/lib/to-error-message";
+import { cn } from "@/shared/lib/utils";
 import type { ProviderConnectionView } from "@/features/provider-settings/model/api";
 import {
   useProviderConnectionMutations,
@@ -28,6 +30,42 @@ function providerLabel(
 ): string {
   const entry = catalog?.providers.find((provider) => provider.id === providerId);
   return entry?.name ?? providerId;
+}
+
+function PlusIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <path d="M12 5v14M5 12h14" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function PanelHeader({ title, description }: { title: string; description?: string }) {
+  return (
+    <header>
+      <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted-strong)]">
+        Providers
+      </p>
+      <h2 className="mt-1 text-base font-semibold text-foreground">{title}</h2>
+      {description ? (
+        <p className="mt-1 max-w-prose text-xs leading-relaxed text-muted-foreground">
+          {description}
+        </p>
+      ) : null}
+    </header>
+  );
+}
+
+function MessageRow({ status, error }: { status?: string; error?: string }) {
+  if (!status && !error) {
+    return null;
+  }
+  return (
+    <div className="flex flex-col gap-1 text-[11px]">
+      {status ? <p className="text-muted-foreground">{status}</p> : null}
+      {error ? <p className="text-rose-400">{error}</p> : null}
+    </div>
+  );
 }
 
 export function ProviderSettingsPanel({ tauriRuntime }: Props) {
@@ -78,29 +116,28 @@ export function ProviderSettingsPanel({ tauriRuntime }: Props) {
 
   if (!tauriRuntime) {
     return (
-      <section className="rounded-lg border bg-muted/40 p-4 text-sm">
-        <h2 className="font-medium">Providers</h2>
-        <p className="mt-2 text-muted-foreground">
-          Open in Tauri desktop runtime to manage provider connections.
-        </p>
+      <section className="flex flex-col gap-3">
+        <PanelHeader
+          title="Providers"
+          description="Open in Tauri desktop runtime to manage provider connections."
+        />
       </section>
     );
   }
 
   if (catalogQuery.isLoading || connectionsQuery.isLoading) {
     return (
-      <section className="rounded-lg border bg-muted/40 p-4 text-sm">
-        <h2 className="font-medium">Providers</h2>
-        <p className="mt-2 text-muted-foreground">Loading providers...</p>
+      <section className="flex flex-col gap-3">
+        <PanelHeader title="Providers" description="Loading providers..." />
       </section>
     );
   }
 
   if (catalogQuery.error || connectionsQuery.error) {
     return (
-      <section className="rounded-lg border bg-muted/40 p-4 text-sm">
-        <h2 className="font-medium">Providers</h2>
-        <p className="mt-2 text-destructive">
+      <section className="flex flex-col gap-3">
+        <PanelHeader title="Providers" />
+        <p className="rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-400">
           Failed to load providers: {toErrorMessage(catalogQuery.error ?? connectionsQuery.error)}
         </p>
       </section>
@@ -113,132 +150,133 @@ export function ProviderSettingsPanel({ tauriRuntime }: Props) {
 
   if (view.mode === "add") {
     return (
-      <section className="rounded-lg border bg-muted/40 p-4 text-sm">
-        <ConnectionEditor
-          mode="add"
-          catalog={catalog}
-          onDone={(created) => {
-            setStatus(`${created.displayName} added.`);
-            setView({ mode: "list" });
-          }}
-          onCancel={() => setView({ mode: "list" })}
-        />
-      </section>
+      <ConnectionEditor
+        mode="add"
+        catalog={catalog}
+        onDone={(created) => {
+          setStatus(`${created.displayName} added.`);
+          setView({ mode: "list" });
+        }}
+        onCancel={() => setView({ mode: "list" })}
+      />
     );
   }
 
   if (view.mode === "edit") {
     return (
-      <section className="rounded-lg border bg-muted/40 p-4 text-sm">
-        <ConnectionEditor
-          mode="edit"
-          catalog={catalog}
-          initialConnection={view.connection}
-          onDone={(updated) => {
-            setStatus(`${updated.displayName} updated.`);
-            setView({ mode: "list" });
-          }}
-          onCancel={() => setView({ mode: "list" })}
-        />
-      </section>
+      <ConnectionEditor
+        mode="edit"
+        catalog={catalog}
+        initialConnection={view.connection}
+        onDone={(updated) => {
+          setStatus(`${updated.displayName} updated.`);
+          setView({ mode: "list" });
+        }}
+        onCancel={() => setView({ mode: "list" })}
+      />
     );
   }
 
   return (
-    <section className="rounded-lg border bg-muted/40 p-4 text-sm">
-      <header className="flex items-start justify-between gap-2">
-        <div>
-          <h2 className="font-medium">Providers</h2>
-          <p className="mt-1 text-muted-foreground">
-            Add provider connections and pick which one the chat uses. API keys are stored in the OS
-            credential store and never returned to the UI.
-          </p>
-        </div>
+    <section className="flex flex-col gap-4">
+      <div className="flex items-start justify-between gap-3">
+        <PanelHeader
+          title="Connections"
+          description="Add provider connections and pick which one the chat uses. API keys are stored in the OS credential store and never returned to the UI."
+        />
         <Button
           type="button"
+          variant="primary"
           size="sm"
           onClick={() => {
             clearMessages();
             setView({ mode: "add" });
           }}
         >
-          Add provider
+          <PlusIcon /> Add provider
         </Button>
-      </header>
+      </div>
 
       {connections.length === 0 ? (
-        <p className="mt-4 rounded-md border border-border/70 bg-background/80 p-3 text-xs text-muted-foreground">
+        <div className="rounded-lg border border-dashed border-border bg-surface-1 px-4 py-6 text-center text-xs text-muted-foreground">
           No provider connections yet. Add one to enable the chat composer.
-        </p>
+        </div>
       ) : (
-        <ul className="mt-4 grid gap-2">
+        <ul className="flex flex-col gap-2">
           {connections.map((connection) => {
             const isActive = active?.connectionId === connection.id;
             const isBusy = pendingId === connection.id;
             return (
               <li
                 key={connection.id}
-                className="flex flex-col gap-2 rounded-md border border-border/70 bg-background/80 p-3 md:flex-row md:items-center md:justify-between"
+                className={cn(
+                  "rounded-lg border border-border bg-surface-1 px-3 py-3 transition-colors",
+                  isActive && "border-l-2 border-l-indigo-500",
+                )}
               >
-                <div className="grid gap-0.5">
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium">{connection.displayName}</span>
-                    <span className="rounded-full border border-border/70 px-2 py-0.5 text-[10px] uppercase tracking-wider text-muted-foreground">
-                      {providerLabel(catalog, connection.providerId)}
-                    </span>
-                    {isActive ? (
-                      <span className="rounded-full bg-primary px-2 py-0.5 text-[10px] uppercase tracking-wider text-primary-foreground">
-                        Active
+                <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                  <div className="grid min-w-0 gap-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-medium text-foreground">
+                        {connection.displayName}
                       </span>
-                    ) : null}
-                    {!connection.hasApiKey ? (
-                      <span className="rounded-full border border-destructive/60 px-2 py-0.5 text-[10px] uppercase tracking-wider text-destructive">
-                        No API key
+                      <Badge tone="neutral">{providerLabel(catalog, connection.providerId)}</Badge>
+                      {isActive ? (
+                        <Badge tone="indigo" withDot>
+                          Active
+                        </Badge>
+                      ) : null}
+                      {!connection.hasApiKey ? (
+                        <Badge tone="rose" withDot>
+                          No API key
+                        </Badge>
+                      ) : null}
+                    </div>
+                    <div className="text-[11px] text-muted-foreground">
+                      Model:{" "}
+                      <span className="font-mono text-foreground/80">
+                        {connection.defaultModel}
                       </span>
-                    ) : null}
+                    </div>
+                    <div className="break-all font-mono text-[10px] text-[color:var(--text-muted-strong)]">
+                      {connection.baseUrl}
+                    </div>
                   </div>
-                  <div className="text-xs text-muted-foreground">
-                    Model:{" "}
-                    <span className="font-mono text-foreground/80">{connection.defaultModel}</span>
-                  </div>
-                  <div className="break-all text-[11px] text-muted-foreground">
-                    {connection.baseUrl}
-                  </div>
-                </div>
 
-                <div className="flex flex-wrap items-center gap-1">
-                  {!isActive ? (
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    {!isActive ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => void makeActive(connection)}
+                        disabled={isBusy}
+                      >
+                        {isBusy ? "Switching..." : "Use this"}
+                      </Button>
+                    ) : null}
                     <Button
                       type="button"
                       size="sm"
-                      variant="outline"
-                      onClick={() => void makeActive(connection)}
+                      variant="ghost"
+                      onClick={() => {
+                        clearMessages();
+                        setView({ mode: "edit", connection });
+                      }}
                       disabled={isBusy}
                     >
-                      {isBusy ? "Switching..." : "Use this"}
+                      Edit
                     </Button>
-                  ) : null}
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => {
-                      clearMessages();
-                      setView({ mode: "edit", connection });
-                    }}
-                    disabled={isBusy}
-                  >
-                    Edit
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => void remove(connection)}
-                    disabled={isBusy}
-                  >
-                    {isBusy ? "..." : "Remove"}
-                  </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="danger"
+                      onClick={() => void remove(connection)}
+                      disabled={isBusy}
+                    >
+                      {isBusy ? "..." : "Remove"}
+                    </Button>
+                  </div>
                 </div>
               </li>
             );
@@ -246,8 +284,7 @@ export function ProviderSettingsPanel({ tauriRuntime }: Props) {
         </ul>
       )}
 
-      {status ? <p className="mt-3 text-xs text-muted-foreground">{status}</p> : null}
-      {actionError ? <p className="mt-2 text-xs text-destructive">{actionError}</p> : null}
+      <MessageRow status={status} error={actionError} />
     </section>
   );
 }

--- a/src/features/settings-modal/ui/settings-category-placeholder.tsx
+++ b/src/features/settings-modal/ui/settings-category-placeholder.tsx
@@ -6,12 +6,20 @@ type Props = {
 
 export function SettingsCategoryPlaceholder({ section }: Props) {
   return (
-    <section className="flex flex-col rounded-xl border border-dashed border-border/70 bg-muted/20 p-5">
-      <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">Planned section</p>
-      <h3 className="mt-3 text-lg font-semibold tracking-tight">{section.title}</h3>
-      <p className="mt-2 text-sm text-muted-foreground">{section.description}</p>
+    <section className="flex flex-col gap-4">
+      <header>
+        <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted-strong)]">
+          Planned section
+        </p>
+        <h3 className="mt-1 text-base font-semibold tracking-tight text-foreground">
+          {section.title}
+        </h3>
+        <p className="mt-2 max-w-prose text-xs leading-relaxed text-muted-foreground">
+          {section.description}
+        </p>
+      </header>
 
-      <div className="mt-6 rounded-lg border border-border/70 bg-background/70 p-4 text-sm text-muted-foreground">
+      <div className="rounded-lg border border-dashed border-border bg-surface-1 px-4 py-6 text-center text-xs text-muted-foreground">
         Settings controls for this category will be added in follow-up tasks.
       </div>
     </section>

--- a/src/features/settings-modal/ui/settings-modal-content.tsx
+++ b/src/features/settings-modal/ui/settings-modal-content.tsx
@@ -11,8 +11,8 @@ type Props = {
 
 export function SettingsModalContent({ sections, sectionContent }: Props) {
   return (
-    <ScrollArea className="min-h-0 flex-1">
-      <div className="p-4">
+    <ScrollArea className="min-h-0 flex-1 bg-card">
+      <div className="px-5 py-4">
         {sections.map((section) => (
           <TabsContent key={section.id} value={section.id} className="m-0 h-full">
             {sectionContent?.[section.id] ?? <SettingsCategoryPlaceholder section={section} />}

--- a/src/features/settings-modal/ui/settings-modal-sidebar.tsx
+++ b/src/features/settings-modal/ui/settings-modal-sidebar.tsx
@@ -9,13 +9,16 @@ export function SettingsModalSidebar({ sections }: Props) {
   return (
     <TabsList
       aria-label="Settings categories"
-      className="flex h-full w-[25vw] shrink-0 flex-col items-stretch justify-start gap-1 rounded-none border-r border-border/70 bg-muted/25 p-2"
+      className="flex h-full w-[200px] shrink-0 flex-col items-stretch justify-start gap-0.5 rounded-none border-r border-border bg-surface-1 p-2"
     >
+      <p className="px-2 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted-strong)]">
+        Categories
+      </p>
       {sections.map((section) => (
         <TabsTrigger
           key={section.id}
           value={section.id}
-          className="h-auto justify-start rounded-lg px-3 py-2 text-left text-sm"
+          className="h-auto justify-start gap-2 rounded-md px-3 py-2 text-left text-xs font-medium data-[state=active]:border data-[state=active]:border-indigo-500/30 data-[state=active]:bg-indigo-500/10 data-[state=active]:text-foreground hover:bg-surface-2"
         >
           {section.label}
         </TabsTrigger>

--- a/src/features/settings-modal/ui/settings-modal.tsx
+++ b/src/features/settings-modal/ui/settings-modal.tsx
@@ -19,6 +19,14 @@ type Props = {
   sectionContent?: Partial<Record<SettingsSectionId, ReactNode>>;
 };
 
+function CloseGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden>
+      <path d="M6 6l12 12M18 6L6 18" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 export function SettingsModal({ open, onClose, sectionContent }: Props) {
   return (
     <Dialog
@@ -32,17 +40,17 @@ export function SettingsModal({ open, onClose, sectionContent }: Props) {
       <DialogContent
         withPortal={false}
         overlayClassName="absolute inset-0 z-20 rounded-[inherit] bg-background/60 backdrop-blur-sm"
-        className="absolute inset-x-6 top-1/2 z-30 flex h-[min(36rem,calc(100%-3rem))] w-[calc(100%-3rem)] max-w-5xl -translate-y-1/2 translate-x-0 flex-col gap-0 overflow-hidden p-0"
+        className="absolute inset-x-6 top-1/2 z-30 flex h-[min(36rem,calc(100%-3rem))] w-[calc(100%-3rem)] max-w-5xl -translate-y-1/2 translate-x-0 flex-col gap-0 overflow-hidden rounded-xl border border-[color:var(--input)] bg-card p-0"
       >
-        <DialogHeader className="flex-row items-start justify-between gap-3 border-b border-border/70 px-5 py-3 text-left">
-          <div>
+        <DialogHeader className="flex-row items-start justify-between gap-3 border-b border-border px-5 py-3 text-left">
+          <div className="space-y-1">
             <DialogTitle>Settings</DialogTitle>
             <DialogDescription>Configure overlay behavior and integrations.</DialogDescription>
           </div>
 
           <DialogClose asChild>
-            <Button type="button" size="sm" variant="ghost">
-              Close
+            <Button type="button" variant="ghost" size="icon-sm" aria-label="Close">
+              <CloseGlyph />
             </Button>
           </DialogClose>
         </DialogHeader>

--- a/src/shared/ui/badge.tsx
+++ b/src/shared/ui/badge.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/shared/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center gap-1 rounded-full px-2 py-[3px] text-[10px] font-medium leading-none whitespace-nowrap border",
+  {
+    variants: {
+      tone: {
+        indigo: "bg-indigo-500/15 text-indigo-200 border-indigo-500/25",
+        amber: "bg-amber-500/15 text-amber-400 border-amber-500/25",
+        teal: "bg-teal-500/12 text-teal-400 border-teal-500/20",
+        rose: "bg-rose-500/12 text-rose-400 border-rose-500/20",
+        green: "bg-green-500/12 text-green-400 border-green-500/20",
+        neutral: "bg-surface-2 text-muted-foreground border-[color:var(--input)]",
+      },
+    },
+    defaultVariants: {
+      tone: "neutral",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>, VariantProps<typeof badgeVariants> {
+  withDot?: boolean;
+}
+
+export function Badge({ className, tone, withDot, children, ...props }: BadgeProps) {
+  return (
+    <span className={cn(badgeVariants({ tone }), className)} {...props}>
+      {withDot ? (
+        <span aria-hidden className="inline-block size-[5px] rounded-full bg-current" />
+      ) : null}
+      {children}
+    </span>
+  );
+}

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -5,23 +5,31 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/shared/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-1.5 whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
-        destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        default: "bg-primary text-primary-foreground shadow-sm hover:bg-indigo-600",
+        primary: "bg-primary text-primary-foreground shadow-sm hover:bg-indigo-600",
+        secondary:
+          "bg-surface-2 text-foreground border border-[color:var(--input)] hover:bg-surface-3",
+        ghost:
+          "bg-transparent text-muted-foreground border border-border hover:bg-surface-2 hover:text-foreground",
         outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-        secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-transparent text-muted-foreground border border-border hover:bg-surface-2 hover:text-foreground",
+        danger:
+          "bg-rose-500/15 text-rose-400 border border-rose-500/25 hover:bg-rose-500/25 hover:text-rose-400",
+        destructive:
+          "bg-rose-500/15 text-rose-400 border border-rose-500/25 hover:bg-rose-500/25 hover:text-rose-400",
+        link: "text-indigo-200 underline-offset-4 hover:underline border-0 bg-transparent",
       },
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
+        default: "h-9 px-4 text-xs rounded-md [&_svg]:size-3.5",
+        sm: "h-7 px-3 text-[11px] rounded-sm [&_svg]:size-3",
+        lg: "h-10 px-5 text-sm rounded-md [&_svg]:size-4",
+        icon: "h-9 w-9 rounded-md [&_svg]:size-4",
+        "icon-sm": "h-7 w-7 rounded-sm [&_svg]:size-3.5",
+        "icon-xs": "h-6 w-6 rounded-sm [&_svg]:size-3",
       },
     },
     defaultVariants: {

--- a/src/shared/ui/dialog.tsx
+++ b/src/shared/ui/dialog.tsx
@@ -15,7 +15,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-background/70 backdrop-blur-sm data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -43,7 +43,7 @@ const DialogContent = React.forwardRef<
         <DialogPrimitive.Content
           ref={ref}
           className={cn(
-            "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-border/80 bg-card p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+            "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border border-[color:var(--input)] bg-card p-6 shadow-2xl duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
             className,
           )}
           {...props}
@@ -76,7 +76,7 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    className={cn("text-base font-semibold leading-none tracking-tight", className)}
     {...props}
   />
 ));
@@ -88,7 +88,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-xs text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/src/shared/ui/tabs.tsx
+++ b/src/shared/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "inline-flex items-center justify-center gap-1 rounded-md bg-surface-2 p-1 text-muted-foreground",
       className,
     )}
     {...props}
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-xs font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/60 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-surface-3 data-[state=active]:text-foreground hover:text-foreground",
       className,
     )}
     {...props}
@@ -42,7 +42,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "ring-offset-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1",
+      "ring-offset-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/60",
       className,
     )}
     {...props}


### PR DESCRIPTION
Replace the neutral monochrome palette with the Lumina Chat design system:
- New color scheme: indigo primary (#6366f1), amber/teal/rose/green accents
- Surface palette: #0c0e14 → #131720 → #1a1f2e → #222840
- Typography: Sora + Fira Code fonts with refined sizing (10–26px)
- Radius scale: 6/10/14/20px for sm/md/lg/xl
- Chat bubbles with avatars, thinking indicator, status badges
- Redesigned settings modal sidebar with indigo highlights
- Updated button variants: primary/secondary/ghost/danger with proper sizing
- New Badge component with color tones (indigo/amber/teal/rose/green/neutral)
- Overlay shell with gradient glow effect and improved spacing

Passes: format, lint, typecheck, test (34/34), Rust check.

## Summary

What changed and why?

## Scope

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Infrastructure / CI
- [ ] Documentation

## Why now

What problem does this PR solve?

## Validation

How was this verified?

- [ ] `npm run check`
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml`
- [ ] Manual verification (if applicable)

## Risks

Known tradeoffs, limitations, or follow-ups.

## Documentation

- [ ] Docs updated
- [ ] `CHANGELOG.md` updated for user-facing changes
- [ ] Internal-only change: used `[skip-changelog]` in PR title/body with rationale
- [ ] Docs not needed (explain in Summary)

## Before requesting review

- [ ] Local checks pass
- [ ] CI is green
