### PR TITLE
refactor(ui): replace inline SVGs with lucide-react and extract Panel…

### DIFF
--- a/src/features/chat-shell/ui/chat-shell.tsx
+++ b/src/features/chat-shell/ui/chat-shell.tsx
@@ -1,6 +1,8 @@
+import { ArrowUp, User } from "lucide-react";
 import type { ChatAvailability } from "@/features/chat-shell/model/use-chat-shell";
 import { useChatShell } from "@/features/chat-shell/model/use-chat-shell";
 import { Badge } from "@/shared/ui/badge";
+import { PanelHeader } from "@/shared/ui/panel-header";
 import { cn } from "@/shared/lib/utils";
 
 type Props = {
@@ -64,23 +66,6 @@ function providerModel(availability: ChatAvailability): string | null {
   return null;
 }
 
-function SendIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-      <path d="M12 20V4M5 11l7-7 7 7" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-}
-
-function UserGlyph() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden>
-      <circle cx="12" cy="8" r="3.5" />
-      <path d="M5 20c1.5-3.5 4.2-5 7-5s5.5 1.5 7 5" strokeLinecap="round" />
-    </svg>
-  );
-}
-
 export function ChatShell({ tauriRuntime }: Props) {
   const { availability, draft, isSending, messages, sendError, sendStatus, setDraft, submitDraft } =
     useChatShell(tauriRuntime);
@@ -92,13 +77,8 @@ export function ChatShell({ tauriRuntime }: Props) {
 
   return (
     <section className="flex flex-1 flex-col gap-4 px-4 py-4">
-      <div className="flex items-end justify-between gap-3">
-        <div>
-          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted-strong)]">
-            Overlay Chat
-          </p>
-          <h1 className="mt-1 text-lg font-semibold leading-tight tracking-tight">Chat</h1>
-        </div>
+      <div className="flex items-start justify-between gap-3">
+        <PanelHeader eyebrow="Overlay Chat" title="Chat" as="h1" />
         <div className="flex flex-col items-end gap-1.5">
           <StatusIndicator availability={availability} />
           {model ? (
@@ -132,7 +112,7 @@ export function ChatShell({ tauriRuntime }: Props) {
                   )}
                   aria-hidden
                 >
-                  {isUser ? <UserGlyph /> : "AI"}
+                  {isUser ? <User className="size-3.5" /> : "AI"}
                 </span>
                 <p
                   className={cn(
@@ -200,7 +180,7 @@ export function ChatShell({ tauriRuntime }: Props) {
           title="Send"
           className="flex size-8 shrink-0 items-center justify-center rounded-md bg-primary text-white shadow-sm transition-colors hover:bg-indigo-600 disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:size-4"
         >
-          <SendIcon />
+          <ArrowUp />
           <span className="sr-only">{isSending ? "Sending..." : "Send"}</span>
         </button>
       </form>

--- a/src/features/hotkey-settings/ui/hotkey-settings-panel.tsx
+++ b/src/features/hotkey-settings/ui/hotkey-settings-panel.tsx
@@ -3,6 +3,7 @@ import { useHotkeySettings } from "@/features/hotkey-settings/model";
 import { toHotkeyAccelerator } from "@/features/hotkey-settings/model/hotkey-accelerator";
 import type { HotkeyAction } from "@/shared/config/hotkeys";
 import { Button } from "@/shared/ui/button";
+import { PanelHeader } from "@/shared/ui/panel-header";
 
 type Props = {
   tauriRuntime: boolean;
@@ -75,15 +76,7 @@ export function HotkeySettingsPanel({ tauriRuntime }: Props) {
 
   return (
     <section className="flex flex-col gap-4">
-      <header>
-        <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted-strong)]">
-          Hotkeys
-        </p>
-        <h2 className="mt-1 text-base font-semibold text-foreground">Keyboard shortcuts</h2>
-        <p className="mt-1 max-w-prose text-xs leading-relaxed text-muted-foreground">
-          {hotkeySupportHint}
-        </p>
-      </header>
+      <PanelHeader eyebrow="Hotkeys" title="Keyboard shortcuts" description={hotkeySupportHint} />
 
       <ul className="flex flex-col gap-2">
         {hotkeyRows.map((hotkeyRow) => {

--- a/src/features/overlay-header/ui/overlay-header.tsx
+++ b/src/features/overlay-header/ui/overlay-header.tsx
@@ -1,3 +1,4 @@
+import { Settings2, X } from "lucide-react";
 import { useOverlayWindowControls } from "@/features/overlay-header/model/use-overlay-window-controls";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
@@ -18,23 +19,6 @@ function LogoMark() {
         <circle cx="9" cy="9" r="2.5" />
       </svg>
     </span>
-  );
-}
-
-function GearIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden>
-      <circle cx="12" cy="12" r="3" />
-      <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.87l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.7 1.7 0 0 0-1.87-.34 1.7 1.7 0 0 0-1.03 1.56V21a2 2 0 1 1-4 0v-.09a1.7 1.7 0 0 0-1.11-1.56 1.7 1.7 0 0 0-1.87.34l-.06.06A2 2 0 1 1 4.13 16.92l.06-.06a1.7 1.7 0 0 0 .34-1.87 1.7 1.7 0 0 0-1.56-1.03H3a2 2 0 1 1 0-4h.09A1.7 1.7 0 0 0 4.65 8.85a1.7 1.7 0 0 0-.34-1.87l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.7 1.7 0 0 0 1.87.34H9a1.7 1.7 0 0 0 1.03-1.56V3a2 2 0 1 1 4 0v.09a1.7 1.7 0 0 0 1.03 1.56 1.7 1.7 0 0 0 1.87-.34l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.7 1.7 0 0 0-.34 1.87V9a1.7 1.7 0 0 0 1.56 1.03H21a2 2 0 1 1 0 4h-.09a1.7 1.7 0 0 0-1.51 1z" />
-    </svg>
-  );
-}
-
-function CloseIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden>
-      <path d="M6 6l12 12M18 6L6 18" strokeLinecap="round" />
-    </svg>
   );
 }
 
@@ -71,7 +55,7 @@ export function OverlayHeader({ tauriRuntime, onOpenSettings }: Props) {
         aria-label="Settings"
         title="Settings"
       >
-        <GearIcon />
+        <Settings2 />
       </Button>
 
       <Button
@@ -83,7 +67,7 @@ export function OverlayHeader({ tauriRuntime, onOpenSettings }: Props) {
         aria-label={isClosePending ? "Closing..." : "Close app"}
         title={isClosePending ? "Closing..." : "Close app"}
       >
-        <CloseIcon />
+        <X />
       </Button>
     </header>
   );

--- a/src/features/provider-settings/ui/connection-editor.tsx
+++ b/src/features/provider-settings/ui/connection-editor.tsx
@@ -1,7 +1,9 @@
 import { useMemo, useState } from "react";
+import { X } from "lucide-react";
 import { findCatalogProvider, type ProviderCatalog } from "@/shared/lib/providers";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
+import { PanelHeader } from "@/shared/ui/panel-header";
 import { toErrorMessage } from "@/shared/lib/to-error-message";
 import type { ProviderConnectionView } from "@/features/provider-settings/model/api";
 import {
@@ -139,21 +141,20 @@ export function ConnectionEditor({ mode, catalog, initialConnection, onDone, onC
         void submit();
       }}
     >
-      <header className="flex flex-wrap items-baseline justify-between gap-2">
-        <div>
-          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted-strong)]">
-            {mode === "add" ? "New connection" : "Edit connection"}
-          </p>
-          <h3 className="mt-1 text-base font-semibold text-foreground">
-            {mode === "add" ? "Add provider connection" : initialConnection?.displayName}
-          </h3>
-        </div>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <PanelHeader
+          as="h3"
+          eyebrow={mode === "add" ? "New connection" : "Edit connection"}
+          title={
+            mode === "add" ? "Add provider connection" : (initialConnection?.displayName ?? "")
+          }
+        />
         {provider?.protocol ? (
           <Badge tone="indigo" className="font-mono">
             {provider.protocol}
           </Badge>
         ) : null}
-      </header>
+      </div>
 
       <div className="grid gap-4">
         <label className="grid gap-1.5">
@@ -245,9 +246,9 @@ export function ConnectionEditor({ mode, catalog, initialConnection, onDone, onC
                     onClick={() => setState((current) => removeCustomModel(current, model))}
                     disabled={isSubmitting}
                     aria-label={`Remove ${model}`}
-                    className="ml-1 text-muted-foreground transition-colors hover:text-rose-400"
+                    className="ml-1 flex items-center text-muted-foreground transition-colors hover:text-rose-400"
                   >
-                    ×
+                    <X className="size-3" />
                   </button>
                 </li>
               ))}

--- a/src/features/provider-settings/ui/provider-settings-panel.tsx
+++ b/src/features/provider-settings/ui/provider-settings-panel.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Plus } from "lucide-react";
 import {
   useActiveProvider,
   useProviderCatalog,
@@ -6,6 +7,7 @@ import {
 } from "@/shared/lib/providers";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
+import { PanelHeader } from "@/shared/ui/panel-header";
 import { toErrorMessage } from "@/shared/lib/to-error-message";
 import { cn } from "@/shared/lib/utils";
 import type { ProviderConnectionView } from "@/features/provider-settings/model/api";
@@ -30,30 +32,6 @@ function providerLabel(
 ): string {
   const entry = catalog?.providers.find((provider) => provider.id === providerId);
   return entry?.name ?? providerId;
-}
-
-function PlusIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-      <path d="M12 5v14M5 12h14" strokeLinecap="round" />
-    </svg>
-  );
-}
-
-function PanelHeader({ title, description }: { title: string; description?: string }) {
-  return (
-    <header>
-      <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted-strong)]">
-        Providers
-      </p>
-      <h2 className="mt-1 text-base font-semibold text-foreground">{title}</h2>
-      {description ? (
-        <p className="mt-1 max-w-prose text-xs leading-relaxed text-muted-foreground">
-          {description}
-        </p>
-      ) : null}
-    </header>
-  );
 }
 
 function MessageRow({ status, error }: { status?: string; error?: string }) {
@@ -118,6 +96,7 @@ export function ProviderSettingsPanel({ tauriRuntime }: Props) {
     return (
       <section className="flex flex-col gap-3">
         <PanelHeader
+          eyebrow="Providers"
           title="Providers"
           description="Open in Tauri desktop runtime to manage provider connections."
         />
@@ -128,7 +107,7 @@ export function ProviderSettingsPanel({ tauriRuntime }: Props) {
   if (catalogQuery.isLoading || connectionsQuery.isLoading) {
     return (
       <section className="flex flex-col gap-3">
-        <PanelHeader title="Providers" description="Loading providers..." />
+        <PanelHeader eyebrow="Providers" title="Providers" description="Loading providers..." />
       </section>
     );
   }
@@ -136,7 +115,7 @@ export function ProviderSettingsPanel({ tauriRuntime }: Props) {
   if (catalogQuery.error || connectionsQuery.error) {
     return (
       <section className="flex flex-col gap-3">
-        <PanelHeader title="Providers" />
+        <PanelHeader eyebrow="Providers" title="Providers" />
         <p className="rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-400">
           Failed to load providers: {toErrorMessage(catalogQuery.error ?? connectionsQuery.error)}
         </p>
@@ -181,6 +160,7 @@ export function ProviderSettingsPanel({ tauriRuntime }: Props) {
     <section className="flex flex-col gap-4">
       <div className="flex items-start justify-between gap-3">
         <PanelHeader
+          eyebrow="Providers"
           title="Connections"
           description="Add provider connections and pick which one the chat uses. API keys are stored in the OS credential store and never returned to the UI."
         />
@@ -193,7 +173,7 @@ export function ProviderSettingsPanel({ tauriRuntime }: Props) {
             setView({ mode: "add" });
           }}
         >
-          <PlusIcon /> Add provider
+          <Plus /> Add provider
         </Button>
       </div>
 

--- a/src/features/settings-modal/ui/settings-category-placeholder.tsx
+++ b/src/features/settings-modal/ui/settings-category-placeholder.tsx
@@ -1,4 +1,5 @@
 import type { SettingsSection } from "@/features/settings-modal/model";
+import { PanelHeader } from "@/shared/ui/panel-header";
 
 type Props = {
   section: SettingsSection;
@@ -7,17 +8,12 @@ type Props = {
 export function SettingsCategoryPlaceholder({ section }: Props) {
   return (
     <section className="flex flex-col gap-4">
-      <header>
-        <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted-strong)]">
-          Planned section
-        </p>
-        <h3 className="mt-1 text-base font-semibold tracking-tight text-foreground">
-          {section.title}
-        </h3>
-        <p className="mt-2 max-w-prose text-xs leading-relaxed text-muted-foreground">
-          {section.description}
-        </p>
-      </header>
+      <PanelHeader
+        as="h3"
+        eyebrow="Planned section"
+        title={section.title}
+        description={section.description}
+      />
 
       <div className="rounded-lg border border-dashed border-border bg-surface-1 px-4 py-6 text-center text-xs text-muted-foreground">
         Settings controls for this category will be added in follow-up tasks.

--- a/src/shared/ui/panel-header.tsx
+++ b/src/shared/ui/panel-header.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+import { cn } from "@/shared/lib/utils";
+
+type Props = {
+  eyebrow: string;
+  title: ReactNode;
+  description?: string;
+  as?: "h1" | "h2" | "h3";
+  className?: string;
+};
+
+export function PanelHeader({ eyebrow, title, description, as: Tag = "h2", className }: Props) {
+  return (
+    <header className={cn("flex flex-col gap-1", className)}>
+      <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted-strong)]">
+        {eyebrow}
+      </p>
+      <Tag className="text-base font-semibold leading-tight text-foreground">{title}</Tag>
+      {description ? (
+        <p className="max-w-prose text-xs leading-relaxed text-muted-foreground">{description}</p>
+      ) : null}
+    </header>
+  );
+}


### PR DESCRIPTION
…Header

Replaces all custom inline SVG icon components (SendIcon, UserGlyph, GearIcon, CloseIcon, PlusIcon) with lucide-react equivalents (ArrowUp, User, Settings2, X, Plus) which were already installed but unused.

Extracts the repeated eyebrow+title+description header pattern into a shared PanelHeader component and adopts it across all five feature panels, removing ~75 lines of duplicated Tailwind class strings.

## Summary

What changed and why?

## Scope

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Infrastructure / CI
- [ ] Documentation

## Why now

What problem does this PR solve?

## Validation

How was this verified?

- [ ] `npm run check`
- [ ] `cargo check --manifest-path src-tauri/Cargo.toml`
- [ ] Manual verification (if applicable)

## Risks

Known tradeoffs, limitations, or follow-ups.

## Documentation

- [ ] Docs updated
- [ ] `CHANGELOG.md` updated for user-facing changes
- [ ] Internal-only change: used `[skip-changelog]` in PR title/body with rationale
- [ ] Docs not needed (explain in Summary)

## Before requesting review

- [ ] Local checks pass
- [ ] CI is green
